### PR TITLE
feat: add BDI mental states skill for cognitive agent modeling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -50,7 +50,17 @@
       "skills": [
         "./skills/project-development"
       ]
+    },
+    {
+      "name": "cognitive-architecture",
+      "description": "BDI mental state modeling and cognitive architecture patterns for building rational agents with formal belief-desire-intention representations",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/bdi-mental-states"
+      ]
     }
   ]
 }
+
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ These skills cover the meta-level practices for building LLM-powered projects.
 
 | Skill | Description |
 |-------|-------------|
-| [project-development](skills/project-development/) | **NEW** Design and build LLM projects from ideation through deployment, including task-model fit analysis, pipeline architecture, and structured output design |
+| [project-development](skills/project-development/) | Design and build LLM projects from ideation through deployment, including task-model fit analysis, pipeline architecture, and structured output design |
+
+### Cognitive Architecture Skills
+
+These skills cover formal cognitive modeling for rational agent systems.
+
+| Skill | Description |
+|-------|-------------|
+| [bdi-mental-states](skills/bdi-mental-states/) | **NEW** Transform external RDF context into agent mental states (beliefs, desires, intentions) using formal BDI ontology patterns for deliberative reasoning and explainability |
 
 ## Design Philosophy
 
@@ -93,6 +101,7 @@ Option B - Direct install via command:
 /plugin install agent-architecture@context-engineering-marketplace
 /plugin install agent-evaluation@context-engineering-marketplace
 /plugin install agent-development@context-engineering-marketplace
+/plugin install cognitive-architecture@context-engineering-marketplace
 ```
 
 ### Local Development
@@ -111,6 +120,7 @@ claude --plugin-dir /path/to/Agent-Skills-for-Context-Engineering
 | `agent-architecture` | multi-agent-patterns, memory-systems, tool-design |
 | `agent-evaluation` | evaluation, advanced-evaluation |
 | `agent-development` | project-development |
+| `cognitive-architecture` | bdi-mental-states |
 
 ### Skill Triggers
 
@@ -126,6 +136,7 @@ claude --plugin-dir /path/to/Agent-Skills-for-Context-Engineering
 | `evaluation` | "evaluate agent performance", "build test framework", "measure quality" |
 | `advanced-evaluation` | "implement LLM-as-judge", "compare model outputs", "mitigate bias" |
 | `project-development` | "start LLM project", "design batch pipeline", "evaluate task-model fit" |
+| `bdi-mental-states` | "model agent mental states", "implement BDI architecture", "transform RDF to beliefs", "build cognitive agent" |
 
 <img width="1014" height="894" alt="Screenshot 2025-12-26 at 12 34 47 PM" src="https://github.com/user-attachments/assets/f79aaf03-fd2d-4c71-a630-7027adeb9bfe" />
 

--- a/skills/bdi-mental-states/SKILL.md
+++ b/skills/bdi-mental-states/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: bdi-mental-states
+description: This skill should be used when the user asks to "model agent mental states", "implement BDI architecture", "create belief-desire-intention models", "transform RDF to beliefs", "build cognitive agent", or mentions BDI ontology, mental state modeling, rational agency, or neuro-symbolic AI integration.
+---
+
+# BDI Mental State Modeling
+
+Transform external RDF context into agent mental states (beliefs, desires, intentions) using formal BDI ontology patterns. This skill enables agents to reason about context through cognitive architecture, supporting deliberative reasoning, explainability, and semantic interoperability within multi-agent systems.
+
+## When to Activate
+
+Activate this skill when:
+- Processing external RDF context into agent beliefs about world states
+- Modeling rational agency with perception, deliberation, and action cycles
+- Enabling explainability through traceable reasoning chains
+- Implementing BDI frameworks (SEMAS, JADE, JADEX)
+- Augmenting LLMs with formal cognitive structures (Logic Augmented Generation)
+- Coordinating mental states across multi-agent platforms
+- Tracking temporal evolution of beliefs, desires, and intentions
+- Linking motivational states to action plans
+
+## Core Concepts
+
+### Mental Reality Architecture
+
+**Mental States (Endurants)**: Persistent cognitive attributes
+- `Belief`: What the agent believes to be true about the world
+- `Desire`: What the agent wishes to bring about
+- `Intention`: What the agent commits to achieving
+
+**Mental Processes (Perdurants)**: Events that modify mental states
+- `BeliefProcess`: Forming/updating beliefs from perception
+- `DesireProcess`: Generating desires from beliefs
+- `IntentionProcess`: Committing to desires as actionable intentions
+
+### Cognitive Chain Pattern
+
+```turtle
+:Belief_store_open a bdi:Belief ;
+    rdfs:comment "Store is open" ;
+    bdi:motivates :Desire_buy_groceries .
+
+:Desire_buy_groceries a bdi:Desire ;
+    rdfs:comment "I desire to buy groceries" ;
+    bdi:isMotivatedBy :Belief_store_open .
+
+:Intention_go_shopping a bdi:Intention ;
+    rdfs:comment "I will buy groceries" ;
+    bdi:fulfils :Desire_buy_groceries ;
+    bdi:isSupportedBy :Belief_store_open ;
+    bdi:specifies :Plan_shopping .
+```
+
+### World State Grounding
+
+Mental states reference structured configurations of the environment:
+
+```turtle
+:Agent_A a bdi:Agent ;
+    bdi:perceives :WorldState_WS1 ;
+    bdi:hasMentalState :Belief_B1 .
+
+:WorldState_WS1 a bdi:WorldState ;
+    rdfs:comment "Meeting scheduled at 10am in Room 5" ;
+    bdi:atTime :TimeInstant_10am .
+
+:Belief_B1 a bdi:Belief ;
+    bdi:refersTo :WorldState_WS1 .
+```
+
+### Goal-Directed Planning
+
+Intentions specify plans that address goals through task sequences:
+
+```turtle
+:Intention_I1 bdi:specifies :Plan_P1 .
+
+:Plan_P1 a bdi:Plan ;
+    bdi:addresses :Goal_G1 ;
+    bdi:beginsWith :Task_T1 ;
+    bdi:endsWith :Task_T3 .
+
+:Task_T1 bdi:precedes :Task_T2 .
+:Task_T2 bdi:precedes :Task_T3 .
+```
+
+## T2B2T Paradigm
+
+Triples-to-Beliefs-to-Triples implements bidirectional flow between RDF knowledge graphs and internal mental states:
+
+**Phase 1: Triples-to-Beliefs**
+```turtle
+# External RDF context triggers belief formation
+:WorldState_notification a bdi:WorldState ;
+    rdfs:comment "Push notification: Payment request $250" ;
+    bdi:triggers :BeliefProcess_BP1 .
+
+:BeliefProcess_BP1 a bdi:BeliefProcess ;
+    bdi:generates :Belief_payment_request .
+```
+
+**Phase 2: Beliefs-to-Triples**
+```turtle
+# Mental deliberation produces new RDF output
+:Intention_pay a bdi:Intention ;
+    bdi:specifies :Plan_payment .
+
+:PlanExecution_PE1 a bdi:PlanExecution ;
+    bdi:satisfies :Plan_payment ;
+    bdi:bringsAbout :WorldState_payment_complete .
+```
+
+## Notation Selection by Level
+
+| C4 Level | Notation | Mental State Representation |
+|----------|----------|----------------------------|
+| L1 Context | ArchiMate | Agent boundaries, external perception sources |
+| L2 Container | ArchiMate | BDI reasoning engine, belief store, plan executor |
+| L3 Component | UML | Mental state managers, process handlers |
+| L4 Code | UML/RDF | Belief/Desire/Intention classes, ontology instances |
+
+## Justification and Explainability
+
+Mental entities link to supporting evidence for traceable reasoning:
+
+```turtle
+:Belief_B1 a bdi:Belief ;
+    bdi:isJustifiedBy :Justification_J1 .
+
+:Justification_J1 a bdi:Justification ;
+    rdfs:comment "Official announcement received via email" .
+
+:Intention_I1 a bdi:Intention ;
+    bdi:isJustifiedBy :Justification_J2 .
+
+:Justification_J2 a bdi:Justification ;
+    rdfs:comment "Location precondition satisfied" .
+```
+
+## Temporal Dimensions
+
+Mental states persist over bounded time periods:
+
+```turtle
+:Belief_B1 a bdi:Belief ;
+    bdi:hasValidity :TimeInterval_TI1 .
+
+:TimeInterval_TI1 a bdi:TimeInterval ;
+    bdi:hasStartTime :TimeInstant_9am ;
+    bdi:hasEndTime :TimeInstant_11am .
+```
+
+Query mental states active at specific moments:
+
+```sparql
+SELECT ?mentalState WHERE {
+    ?mentalState bdi:hasValidity ?interval .
+    ?interval bdi:hasStartTime ?start ;
+              bdi:hasEndTime ?end .
+    FILTER(?start <= "2025-01-04T10:00:00"^^xsd:dateTime && 
+           ?end >= "2025-01-04T10:00:00"^^xsd:dateTime)
+}
+```
+
+## Compositional Mental Entities
+
+Complex mental entities decompose into constituent parts for selective updates:
+
+```turtle
+:Belief_meeting a bdi:Belief ;
+    rdfs:comment "Meeting at 10am in Room 5" ;
+    bdi:hasPart :Belief_meeting_time , :Belief_meeting_location .
+
+# Update only location component
+:BeliefProcess_update a bdi:BeliefProcess ;
+    bdi:modifies :Belief_meeting_location .
+```
+
+## Integration Patterns
+
+### Logic Augmented Generation (LAG)
+
+Augment LLM outputs with ontological constraints:
+
+```python
+def augment_llm_with_bdi_ontology(prompt, ontology_graph):
+    ontology_context = serialize_ontology(ontology_graph, format='turtle')
+    augmented_prompt = f"{ontology_context}\n\n{prompt}"
+    
+    response = llm.generate(augmented_prompt)
+    triples = extract_rdf_triples(response)
+    
+    is_consistent = validate_triples(triples, ontology_graph)
+    return triples if is_consistent else retry_with_feedback()
+```
+
+### SEMAS Rule Translation
+
+Map BDI ontology to executable production rules:
+
+```prolog
+% Belief triggers desire formation
+[HEAD: belief(agent_a, store_open)] / 
+[CONDITIONALS: time(weekday_afternoon)] » 
+[TAIL: generate_desire(agent_a, buy_groceries)].
+
+% Desire triggers intention commitment
+[HEAD: desire(agent_a, buy_groceries)] / 
+[CONDITIONALS: belief(agent_a, has_shopping_list)] » 
+[TAIL: commit_intention(agent_a, buy_groceries)].
+```
+
+## Guidelines
+
+1. Model world states as configurations independent of agent perspectives, providing referential substrate for mental states.
+
+2. Distinguish endurants (persistent mental states) from perdurants (temporal mental processes), aligning with DOLCE ontology.
+
+3. Treat goals as descriptions rather than mental states, maintaining separation between cognitive and planning layers.
+
+4. Use `hasPart` relations for meronymic structures enabling selective belief updates.
+
+5. Associate every mental entity with temporal constructs via `atTime` or `hasValidity`.
+
+6. Use bidirectional property pairs (`motivates`/`isMotivatedBy`, `generates`/`isGeneratedBy`) for flexible querying.
+
+7. Link mental entities to `Justification` instances for explainability and trust.
+
+8. Implement T2B2T through: (1) translate RDF to beliefs, (2) execute BDI reasoning, (3) project mental states back to RDF.
+
+9. Define existential restrictions on mental processes (e.g., `BeliefProcess ⊑ ∃generates.Belief`).
+
+10. Reuse established ODPs (EventCore, Situation, TimeIndexedSituation, BasicPlan, Provenance) for interoperability.
+
+## Competency Questions
+
+Validate implementation against these SPARQL queries:
+
+```sparql
+# CQ1: What beliefs motivated formation of a given desire?
+SELECT ?belief WHERE {
+    :Desire_D1 bdi:isMotivatedBy ?belief .
+}
+
+# CQ2: Which desire does a particular intention fulfill?
+SELECT ?desire WHERE {
+    :Intention_I1 bdi:fulfils ?desire .
+}
+
+# CQ3: Which mental process generated a belief?
+SELECT ?process WHERE {
+    ?process bdi:generates :Belief_B1 .
+}
+
+# CQ4: What is the ordered sequence of tasks in a plan?
+SELECT ?task ?nextTask WHERE {
+    :Plan_P1 bdi:hasComponent ?task .
+    OPTIONAL { ?task bdi:precedes ?nextTask }
+} ORDER BY ?task
+```
+
+## Anti-Patterns
+
+1. **Conflating mental states with world states**: Mental states reference world states, they are not world states themselves.
+
+2. **Missing temporal bounds**: Every mental state should have validity intervals for diachronic reasoning.
+
+3. **Flat belief structures**: Use compositional modeling with `hasPart` for complex beliefs.
+
+4. **Implicit justifications**: Always link mental entities to explicit justification instances.
+
+5. **Direct intention-to-action mapping**: Intentions specify plans which contain tasks; actions execute tasks.
+
+## Integration
+
+- **RDF Processing**: Apply after parsing external RDF context to construct cognitive representations
+- **Semantic Reasoning**: Combine with ontology reasoning to infer implicit mental state relationships
+- **Multi-Agent Communication**: Integrate with FIPA ACL for cross-platform belief sharing
+- **Temporal Context**: Coordinate with temporal reasoning for mental state evolution
+- **Explainable AI**: Feed into explanation systems tracing perception through deliberation to action
+- **Neuro-Symbolic AI**: Apply in LAG pipelines to constrain LLM outputs with cognitive structures
+
+## References
+
+See `references/` folder for detailed documentation:
+- `bdi-ontology-core.md` - Core ontology patterns and class definitions
+- `rdf-examples.md` - Complete RDF/Turtle examples
+- `sparql-competency.md` - Full competency question SPARQL queries
+- `framework-integration.md` - SEMAS, JADE, LAG integration patterns
+
+Primary sources:
+- Zuppiroli et al. "The Belief-Desire-Intention Ontology" (2025)
+- Rao & Georgeff "BDI agents: From theory to practice" (1995)
+- Bratman "Intention, plans, and practical reason" (1987)
+

--- a/skills/bdi-mental-states/references/bdi-ontology-core.md
+++ b/skills/bdi-mental-states/references/bdi-ontology-core.md
@@ -1,0 +1,207 @@
+# BDI Ontology Core Patterns
+
+Core ontology design patterns for Belief-Desire-Intention mental state modeling.
+
+## Class Hierarchy
+
+### Mental Entities (Endurants)
+
+```
+bdi:MentalEntity
+├── bdi:Belief          # Informational dimension
+├── bdi:Desire          # Motivational dimension  
+├── bdi:Intention       # Deliberative dimension
+├── bdi:Goal            # Description of desired end state
+└── bdi:Plan            # Structured action sequence
+```
+
+### Mental Processes (Perdurants)
+
+```
+bdi:MentalProcess
+├── bdi:BeliefProcess      # Forms/updates beliefs from perception
+├── bdi:DesireProcess      # Generates desires from beliefs
+├── bdi:IntentionProcess   # Commits to desires as intentions
+├── bdi:Planning           # Transforms intentions into plans
+└── bdi:PlanExecution      # Executes plan actions
+```
+
+### Supporting Entities
+
+```
+bdi:WorldState        # Configuration of environment
+bdi:Justification     # Evidential basis for mental states
+bdi:Task              # Atomic unit of planned action
+bdi:Action            # Execution of a task
+bdi:TimeInterval      # Temporal validity bounds
+bdi:TimeInstant       # Point in time reference
+```
+
+## Object Properties
+
+### Motivational Relations
+
+| Property | Domain | Range | Description |
+|----------|--------|-------|-------------|
+| `motivates` | Belief | Desire | Belief provides reason for desire |
+| `isMotivatedBy` | Desire | Belief | Inverse of motivates |
+| `fulfils` | Intention | Desire | Intention commits to achieving desire |
+| `isFulfilledBy` | Desire | Intention | Inverse of fulfils |
+| `isSupportedBy` | Intention | Belief | Beliefs supporting intention viability |
+
+### Generative Relations
+
+| Property | Domain | Range | Description |
+|----------|--------|-------|-------------|
+| `generates` | MentalProcess | MentalEntity | Process creates mental state |
+| `isGeneratedBy` | MentalEntity | MentalProcess | Inverse of generates |
+| `modifies` | MentalProcess | MentalEntity | Process updates existing state |
+| `suppresses` | MentalProcess | MentalEntity | Process deactivates state |
+| `isTriggeredBy` | MentalProcess | MentalEntity | State initiates process |
+
+### Referential Relations
+
+| Property | Domain | Range | Description |
+|----------|--------|-------|-------------|
+| `refersTo` | MentalEntity | WorldState | Mental state about world |
+| `perceives` | Agent | WorldState | Agent observes world |
+| `bringsAbout` | Action | WorldState | Action causes world change |
+| `reasonsUpon` | MentalProcess | MentalEntity | Input to reasoning |
+
+### Structural Relations
+
+| Property | Domain | Range | Description |
+|----------|--------|-------|-------------|
+| `hasPart` | MentalEntity | MentalEntity | Meronymic composition |
+| `specifies` | Intention | Plan | Intention defines plan |
+| `addresses` | Plan | Goal | Plan achieves goal |
+| `hasComponent` | Plan | Task | Plan contains tasks |
+| `precedes` | Task | Task | Task ordering |
+
+### Temporal Relations
+
+| Property | Domain | Range | Description |
+|----------|--------|-------|-------------|
+| `atTime` | Entity | TimeInstant | Point occurrence |
+| `hasValidity` | MentalEntity | TimeInterval | Persistence bounds |
+| `hasStartTime` | TimeInterval | TimeInstant | Interval start |
+| `hasEndTime` | TimeInterval | TimeInstant | Interval end |
+
+### Justification Relations
+
+| Property | Domain | Range | Description |
+|----------|--------|-------|-------------|
+| `isJustifiedBy` | MentalEntity | Justification | Evidential support |
+| `justifies` | Justification | MentalEntity | Inverse relation |
+
+## Ontological Restrictions
+
+### Belief Restrictions
+
+```turtle
+bdi:Belief rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bdi:refersTo ;
+    owl:someValuesFrom bdi:WorldState
+] .
+
+bdi:Belief rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bdi:hasValidity ;
+    owl:maxCardinality 1
+] .
+```
+
+### Desire Restrictions
+
+```turtle
+bdi:Desire rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bdi:isMotivatedBy ;
+    owl:someValuesFrom bdi:Belief
+] .
+```
+
+### Intention Restrictions
+
+```turtle
+bdi:Intention rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bdi:fulfils ;
+    owl:cardinality 1
+] .
+
+bdi:Intention rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bdi:isSupportedBy ;
+    owl:someValuesFrom bdi:Belief
+] .
+```
+
+### Mental Process Restrictions
+
+```turtle
+bdi:BeliefProcess rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bdi:generates ;
+    owl:allValuesFrom bdi:Belief
+] .
+
+bdi:DesireProcess rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bdi:generates ;
+    owl:allValuesFrom bdi:Desire
+] .
+
+bdi:IntentionProcess rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty bdi:generates ;
+    owl:allValuesFrom bdi:Intention
+] .
+```
+
+## DOLCE Alignment
+
+The BDI ontology aligns with DOLCE Ultra Lite (DUL) foundational ontology:
+
+| BDI Class | DUL Superclass | Rationale |
+|-----------|----------------|-----------|
+| `Agent` | `dul:Agent` | Intentional entity capable of action |
+| `Belief` | `dul:InformationObject` | Information-bearing entity |
+| `Desire` | `dul:Description` | Describes desired state |
+| `Intention` | `dul:Description` | Describes committed course |
+| `Goal` | `dul:Goal` | Desired end state description |
+| `Plan` | `dul:Plan` | Organized action sequence |
+| `WorldState` | `dul:Situation` | Configuration of entities |
+| `MentalProcess` | `dul:Event` | Temporally extended occurrence |
+| `Task` | `dul:Task` | Unit of planned work |
+| `Action` | `dul:Action` | Performed task instance |
+
+## Reused Ontology Design Patterns
+
+### EventCore Pattern
+Used for mental processes with temporal aspects and participant roles.
+
+### Situation Pattern  
+Used for world state configurations that mental states reference.
+
+### TimeIndexedSituation Pattern
+Used for associating mental states with validity intervals.
+
+### BasicPlan Pattern
+Used for goal-plan-task structures linking intentions to actions.
+
+### Provenance Pattern
+Used for justification tracking and evidential chains.
+
+## Namespace Declarations
+
+```turtle
+@prefix bdi: <https://w3id.org/fossr/ontology/bdi/> .
+@prefix dul: <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+```
+

--- a/skills/bdi-mental-states/references/framework-integration.md
+++ b/skills/bdi-mental-states/references/framework-integration.md
@@ -1,0 +1,582 @@
+# BDI Framework Integration Patterns
+
+Integration patterns for connecting BDI ontology with executable agent frameworks.
+
+## SEMAS Rule Translation
+
+Map BDI ontology constructs to SEMAS production rules.
+
+### Ontology-to-Rule Mapping
+
+| BDI Construct | SEMAS Element | Example |
+|---------------|---------------|---------|
+| Belief | HEAD fact | `belief(agent_a, store_open)` |
+| Supporting beliefs | CONDITIONALS | `[CONDITIONALS: time(weekday)]` |
+| Desire generation | TAIL action | `generate_desire(agent, goal)` |
+| Intention commitment | TAIL action | `commit_intention(agent, goal)` |
+| Plan specification | TAIL action | `create_plan(agent, plan_id)` |
+
+### Rule Templates
+
+**Belief triggers desire formation:**
+```prolog
+[HEAD: belief(Agent, Fact)] / 
+[CONDITIONALS: context_condition(Agent, Context)] » 
+[TAIL: generate_desire(Agent, DesiredState)].
+```
+
+**Desire triggers intention commitment:**
+```prolog
+[HEAD: desire(Agent, Goal)] / 
+[CONDITIONALS: belief(Agent, SupportingFact1), 
+               belief(Agent, SupportingFact2)] » 
+[TAIL: commit_intention(Agent, Goal)].
+```
+
+**Intention triggers planning:**
+```prolog
+[HEAD: intention(Agent, Goal)] / 
+[CONDITIONALS: goal(GoalSpec)] » 
+[TAIL: create_plan(Agent, PlanId)].
+```
+
+**Plan triggers execution:**
+```prolog
+[HEAD: plan(Agent, PlanId)] / 
+[CONDITIONALS: ready_to_execute(Agent)] » 
+[TAIL: execute_plan(Agent, PlanId)].
+```
+
+### Complete SEMAS Example
+
+```prolog
+% ============================================================
+% GROCERY SHOPPING SCENARIO
+% ============================================================
+
+% Phase 1: Belief formation from world state
+[HEAD: perceive(agent_a, store_open)] / 
+[CONDITIONALS: time(weekday_afternoon)] » 
+[TAIL: add_belief(agent_a, store_open)].
+
+% Phase 2: Desire generation from belief
+[HEAD: belief(agent_a, store_open)] / 
+[CONDITIONALS: belief(agent_a, needs_groceries)] » 
+[TAIL: generate_desire(agent_a, buy_groceries)].
+
+% Phase 3: Intention commitment from desire
+[HEAD: desire(agent_a, buy_groceries)] / 
+[CONDITIONALS: belief(agent_a, has_shopping_list), 
+               belief(agent_a, store_open),
+               belief(agent_a, has_transportation)] » 
+[TAIL: commit_intention(agent_a, buy_groceries)].
+
+% Phase 4: Plan creation from intention
+[HEAD: intention(agent_a, buy_groceries)] / 
+[CONDITIONALS: goal(complete_shopping)] » 
+[TAIL: create_plan(agent_a, shopping_plan)].
+
+% Phase 5: Plan execution
+[HEAD: plan(agent_a, shopping_plan)] / 
+[CONDITIONALS: preconditions_met(shopping_plan)] » 
+[TAIL: execute_task(agent_a, drive_to_store),
+       execute_task(agent_a, select_items),
+       execute_task(agent_a, checkout),
+       execute_task(agent_a, return_home)].
+
+% Phase 6: World state update
+[HEAD: task_complete(agent_a, checkout)] / 
+[CONDITIONALS: items_purchased(agent_a)] » 
+[TAIL: update_world_state(has_groceries),
+       remove_desire(agent_a, buy_groceries),
+       remove_intention(agent_a, buy_groceries)].
+```
+
+### Python Translation Layer
+
+```python
+from rdflib import Graph, Namespace, RDF
+
+BDI = Namespace("https://w3id.org/fossr/ontology/bdi/")
+
+def ontology_to_semas_rules(bdi_graph: Graph) -> list[str]:
+    """
+    Translate BDI ontology instances to SEMAS production rules.
+    """
+    rules = []
+    
+    # Extract belief-desire-intention chains
+    for intention in bdi_graph.subjects(RDF.type, BDI.Intention):
+        # Get supporting beliefs
+        supporting_beliefs = list(bdi_graph.objects(intention, BDI.isSupportedBy))
+        
+        # Get fulfilled desire
+        fulfilled_desires = list(bdi_graph.objects(intention, BDI.fulfils))
+        
+        # Get specified plan
+        specified_plans = list(bdi_graph.objects(intention, BDI.specifies))
+        
+        if fulfilled_desires and supporting_beliefs:
+            desire = fulfilled_desires[0]
+            beliefs_str = ", ".join([format_belief(b, bdi_graph) for b in supporting_beliefs])
+            
+            rule = (
+                f"[HEAD: {format_desire(desire, bdi_graph)}] / "
+                f"[CONDITIONALS: {beliefs_str}] » "
+                f"[TAIL: commit_intention({format_intention(intention, bdi_graph)})]"
+            )
+            rules.append(rule)
+        
+        if specified_plans:
+            plan = specified_plans[0]
+            rule = (
+                f"[HEAD: {format_intention(intention, bdi_graph)}] / "
+                f"[CONDITIONALS: ready_to_plan] » "
+                f"[TAIL: create_plan({format_plan(plan, bdi_graph)})]"
+            )
+            rules.append(rule)
+    
+    return rules
+
+def format_belief(belief_uri, graph):
+    label = graph.value(belief_uri, RDFS.label)
+    return f"belief({label or belief_uri.split('/')[-1]})"
+
+def format_desire(desire_uri, graph):
+    label = graph.value(desire_uri, RDFS.label)
+    return f"desire({label or desire_uri.split('/')[-1]})"
+
+def format_intention(intention_uri, graph):
+    label = graph.value(intention_uri, RDFS.label)
+    return f"intention({label or intention_uri.split('/')[-1]})"
+
+def format_plan(plan_uri, graph):
+    label = graph.value(plan_uri, RDFS.label)
+    return f"plan({label or plan_uri.split('/')[-1]})"
+```
+
+## Logic Augmented Generation (LAG)
+
+Augment LLM outputs with BDI ontological constraints.
+
+### LAG Pipeline Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   User Query    │────▶│  Ontology       │────▶│  Augmented      │
+│                 │     │  Injection      │     │  Prompt         │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                                                        │
+                                                        ▼
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Validated      │◀────│  Ontology       │◀────│  LLM Response   │
+│  RDF Triples    │     │  Validation     │     │  (Triples)      │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+```
+
+### LAG Implementation
+
+```python
+from rdflib import Graph, Namespace
+from rdflib.plugins.parsers.notation3 import BadSyntax
+
+BDI = Namespace("https://w3id.org/fossr/ontology/bdi/")
+
+class BDILogicAugmentedGenerator:
+    def __init__(self, ontology_path: str, llm_client):
+        self.ontology = Graph()
+        self.ontology.parse(ontology_path, format='turtle')
+        self.llm = llm_client
+    
+    def generate_mental_states(self, context: str) -> Graph:
+        """
+        Generate BDI mental states from context using LAG.
+        """
+        # Phase 1: Inject ontology into prompt
+        ontology_turtle = self.ontology.serialize(format='turtle')
+        augmented_prompt = self._build_augmented_prompt(context, ontology_turtle)
+        
+        # Phase 2: Generate with LLM
+        response = self.llm.generate(augmented_prompt)
+        
+        # Phase 3: Extract and validate triples
+        triples = self._extract_triples(response)
+        validated = self._validate_against_ontology(triples)
+        
+        if not validated['is_consistent']:
+            # Retry with feedback
+            return self._retry_with_feedback(context, validated['errors'])
+        
+        return validated['graph']
+    
+    def _build_augmented_prompt(self, context: str, ontology: str) -> str:
+        return f"""
+You are a BDI mental state modeler. Given the following context, generate 
+RDF triples representing the agent's beliefs, desires, and intentions.
+
+## BDI Ontology (use these classes and properties):
+{ontology}
+
+## Context to Model:
+{context}
+
+## Instructions:
+1. Identify world states from the context
+2. Generate beliefs that refer to those world states
+3. Generate desires motivated by those beliefs
+4. Generate intentions that fulfill desires and are supported by beliefs
+5. Include justifications for each mental state
+6. Include temporal validity intervals
+
+Output valid Turtle RDF triples only.
+"""
+    
+    def _extract_triples(self, response: str) -> str:
+        """Extract Turtle content from LLM response."""
+        # Find turtle block in response
+        if "```turtle" in response:
+            start = response.find("```turtle") + 9
+            end = response.find("```", start)
+            return response[start:end].strip()
+        return response
+    
+    def _validate_against_ontology(self, triples: str) -> dict:
+        """Validate generated triples against BDI ontology."""
+        result = {'is_consistent': True, 'errors': [], 'graph': None}
+        
+        try:
+            generated = Graph()
+            generated.parse(data=triples, format='turtle')
+            result['graph'] = generated
+            
+            # Validate constraints
+            errors = []
+            
+            # Check: Every intention must fulfill a desire
+            for intention in generated.subjects(RDF.type, BDI.Intention):
+                if not list(generated.objects(intention, BDI.fulfils)):
+                    errors.append(f"Intention {intention} does not fulfill any desire")
+            
+            # Check: Every belief should reference a world state
+            for belief in generated.subjects(RDF.type, BDI.Belief):
+                if not list(generated.objects(belief, BDI.refersTo)):
+                    errors.append(f"Belief {belief} does not reference a world state")
+            
+            # Check: Desires should be motivated by beliefs
+            for desire in generated.subjects(RDF.type, BDI.Desire):
+                if not list(generated.objects(desire, BDI.isMotivatedBy)):
+                    errors.append(f"Desire {desire} has no motivating belief")
+            
+            if errors:
+                result['is_consistent'] = False
+                result['errors'] = errors
+                
+        except BadSyntax as e:
+            result['is_consistent'] = False
+            result['errors'] = [f"Invalid Turtle syntax: {e}"]
+        
+        return result
+    
+    def _retry_with_feedback(self, context: str, errors: list) -> Graph:
+        """Retry generation with error feedback."""
+        feedback_prompt = f"""
+Previous generation had errors:
+{chr(10).join(errors)}
+
+Please regenerate the mental states fixing these issues.
+
+Context: {context}
+"""
+        response = self.llm.generate(feedback_prompt)
+        triples = self._extract_triples(response)
+        result = self._validate_against_ontology(triples)
+        
+        if result['is_consistent']:
+            return result['graph']
+        else:
+            raise ValueError(f"Failed to generate valid mental states: {result['errors']}")
+```
+
+### Inconsistency Detection Example
+
+```python
+def detect_location_inconsistency(graph: Graph) -> list[str]:
+    """
+    Detect inconsistencies where agent cannot be in two places.
+    """
+    inconsistencies = []
+    
+    # Query for location beliefs
+    query = """
+    PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+    
+    SELECT ?agent ?belief1 ?belief2 ?loc1 ?loc2 WHERE {
+        ?agent bdi:hasBelief ?belief1 , ?belief2 .
+        ?belief1 bdi:refersTo ?ws1 .
+        ?belief2 bdi:refersTo ?ws2 .
+        ?ws1 bdi:hasLocation ?loc1 .
+        ?ws2 bdi:hasLocation ?loc2 .
+        FILTER(?belief1 != ?belief2 && ?loc1 != ?loc2)
+        
+        # Check temporal overlap
+        ?belief1 bdi:hasValidity ?interval1 .
+        ?belief2 bdi:hasValidity ?interval2 .
+        ?interval1 bdi:hasStartTime ?start1 ; bdi:hasEndTime ?end1 .
+        ?interval2 bdi:hasStartTime ?start2 ; bdi:hasEndTime ?end2 .
+        FILTER(?start1 < ?end2 && ?start2 < ?end1)
+    }
+    """
+    
+    for row in graph.query(query):
+        inconsistencies.append(
+            f"Agent {row.agent} has conflicting location beliefs: "
+            f"{row.loc1} and {row.loc2} at overlapping times"
+        )
+    
+    return inconsistencies
+```
+
+## JADE/JADEX Integration
+
+Map BDI ontology to JADE/JADEX agent platform structures.
+
+### JADE Agent Structure
+
+```java
+public class BDIAgent extends Agent {
+    // Mental state storage (maps to ontology individuals)
+    private Set<Belief> beliefs = new HashSet<>();
+    private Set<Desire> desires = new HashSet<>();
+    private Set<Intention> intentions = new HashSet<>();
+    
+    // Ontology-backed mental state management
+    private Graph mentalStateGraph;
+    
+    public void addBelief(Belief belief) {
+        beliefs.add(belief);
+        
+        // Add to RDF graph
+        Resource beliefResource = mentalStateGraph.createResource(belief.getUri());
+        beliefResource.addProperty(RDF.type, BDI.Belief);
+        beliefResource.addProperty(BDI.refersTo, belief.getWorldState().getUri());
+        beliefResource.addProperty(BDI.hasValidity, createInterval(belief.getValidity()));
+        
+        // Trigger desire formation
+        triggerDesireProcess(belief);
+    }
+    
+    public void commitIntention(Intention intention) {
+        intentions.add(intention);
+        
+        Resource intentionResource = mentalStateGraph.createResource(intention.getUri());
+        intentionResource.addProperty(RDF.type, BDI.Intention);
+        intentionResource.addProperty(BDI.fulfils, intention.getDesire().getUri());
+        
+        for (Belief support : intention.getSupportingBeliefs()) {
+            intentionResource.addProperty(BDI.isSupportedBy, support.getUri());
+        }
+        
+        // Trigger planning
+        triggerPlanning(intention);
+    }
+    
+    // Export mental states as RDF
+    public String exportMentalStates() {
+        return mentalStateGraph.serialize(Format.TURTLE);
+    }
+    
+    // Import mental states from RDF
+    public void importMentalStates(String turtle) {
+        Graph imported = new Graph();
+        imported.parse(turtle, Format.TURTLE);
+        
+        // Reconstruct Java objects from RDF
+        for (Resource belief : imported.listSubjectsWithProperty(RDF.type, BDI.Belief)) {
+            Belief b = reconstructBelief(belief);
+            beliefs.add(b);
+        }
+        // ... similar for desires and intentions
+    }
+}
+```
+
+### JADEX Goal Mapping
+
+```java
+// Map BDI ontology goals to JADEX goals
+@Goal
+public class OntologyBackedGoal {
+    @GoalParameter
+    protected String goalUri;
+    
+    @GoalParameter
+    protected Graph ontologyGraph;
+    
+    public OntologyBackedGoal(Resource goalResource, Graph graph) {
+        this.goalUri = goalResource.getURI();
+        this.ontologyGraph = graph;
+    }
+    
+    @GoalTargetCondition
+    public boolean isAchieved() {
+        // Query ontology for goal achievement
+        String query = """
+            PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+            ASK {
+                ?execution bdi:addresses <%s> ;
+                           bdi:bringsAbout ?worldState .
+            }
+            """.formatted(goalUri);
+        
+        return ontologyGraph.ask(query);
+    }
+    
+    @GoalDropCondition
+    public boolean shouldDrop() {
+        // Check if supporting beliefs are invalidated
+        String query = """
+            PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+            ASK {
+                ?intention bdi:specifies ?plan .
+                ?plan bdi:addresses <%s> .
+                ?intention bdi:isSupportedBy ?belief .
+                ?belief bdi:hasValidity ?interval .
+                ?interval bdi:hasEndTime ?end .
+                FILTER(?end < NOW())
+            }
+            """.formatted(goalUri);
+        
+        return ontologyGraph.ask(query);
+    }
+}
+```
+
+## RDF Triple Store Integration
+
+### Triple Store Configuration
+
+```python
+from rdflib import Graph
+from rdflib.plugins.stores.sparqlstore import SPARQLUpdateStore
+
+class BDIMentalStateStore:
+    def __init__(self, endpoint: str):
+        self.store = SPARQLUpdateStore()
+        self.store.open((endpoint + "/query", endpoint + "/update"))
+        self.graph = Graph(store=self.store, identifier="http://example.org/bdi")
+    
+    def add_belief(self, agent_uri: str, belief_data: dict):
+        """Add belief to triple store."""
+        belief_uri = f"{agent_uri}/belief/{belief_data['id']}"
+        
+        self.graph.add((URIRef(belief_uri), RDF.type, BDI.Belief))
+        self.graph.add((URIRef(belief_uri), RDFS.label, Literal(belief_data['label'])))
+        self.graph.add((URIRef(belief_uri), BDI.refersTo, URIRef(belief_data['world_state'])))
+        self.graph.add((URIRef(agent_uri), BDI.hasMentalState, URIRef(belief_uri)))
+        
+        # Add temporal validity
+        interval_uri = f"{belief_uri}/validity"
+        self.graph.add((URIRef(belief_uri), BDI.hasValidity, URIRef(interval_uri)))
+        self.graph.add((URIRef(interval_uri), BDI.hasStartTime, 
+                        Literal(belief_data['start_time'], datatype=XSD.dateTime)))
+        self.graph.add((URIRef(interval_uri), BDI.hasEndTime,
+                        Literal(belief_data['end_time'], datatype=XSD.dateTime)))
+    
+    def get_active_beliefs(self, agent_uri: str, at_time: datetime) -> list:
+        """Query beliefs active at specific time."""
+        query = """
+        PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        
+        SELECT ?belief ?label WHERE {
+            <%s> bdi:hasMentalState ?belief .
+            ?belief a bdi:Belief ;
+                    rdfs:label ?label ;
+                    bdi:hasValidity ?interval .
+            ?interval bdi:hasStartTime ?start ;
+                      bdi:hasEndTime ?end .
+            FILTER(?start <= "%s"^^xsd:dateTime && ?end >= "%s"^^xsd:dateTime)
+        }
+        """ % (agent_uri, at_time.isoformat(), at_time.isoformat())
+        
+        return list(self.graph.query(query))
+    
+    def get_cognitive_chain(self, intention_uri: str) -> dict:
+        """Trace complete cognitive chain for an intention."""
+        query = """
+        PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+        
+        SELECT ?intention ?desire ?belief ?worldState ?plan WHERE {
+            <%s> a bdi:Intention ;
+                 bdi:fulfils ?desire ;
+                 bdi:isSupportedBy ?belief .
+            OPTIONAL { <%s> bdi:specifies ?plan }
+            ?desire bdi:isMotivatedBy ?belief .
+            ?belief bdi:refersTo ?worldState .
+        }
+        """ % (intention_uri, intention_uri)
+        
+        results = list(self.graph.query(query))
+        if results:
+            row = results[0]
+            return {
+                'intention': str(row.intention),
+                'desire': str(row.desire),
+                'belief': str(row.belief),
+                'world_state': str(row.worldState),
+                'plan': str(row.plan) if row.plan else None
+            }
+        return None
+```
+
+## FIPA ACL Integration
+
+Map BDI mental states to FIPA Agent Communication Language.
+
+```python
+from fipa_acl import ACLMessage, Performative
+
+class BDICommunicator:
+    def __init__(self, agent_id: str, mental_state_store: BDIMentalStateStore):
+        self.agent_id = agent_id
+        self.store = mental_state_store
+    
+    def share_belief(self, belief_uri: str, receiver: str) -> ACLMessage:
+        """Create INFORM message to share belief."""
+        belief_triples = self.store.get_belief_as_turtle(belief_uri)
+        
+        message = ACLMessage()
+        message.performative = Performative.INFORM
+        message.sender = self.agent_id
+        message.receiver = receiver
+        message.content = belief_triples
+        message.ontology = "https://w3id.org/fossr/ontology/bdi/"
+        message.language = "turtle"
+        
+        return message
+    
+    def request_belief_confirmation(self, belief_uri: str, receiver: str) -> ACLMessage:
+        """Create QUERY-IF message to confirm shared belief."""
+        message = ACLMessage()
+        message.performative = Performative.QUERY_IF
+        message.sender = self.agent_id
+        message.receiver = receiver
+        message.content = f"ASK {{ <{belief_uri}> a bdi:Belief }}"
+        message.language = "sparql"
+        
+        return message
+    
+    def propose_intention(self, intention_uri: str, receiver: str) -> ACLMessage:
+        """Create PROPOSE message for coordinated intention."""
+        intention_triples = self.store.get_intention_as_turtle(intention_uri)
+        
+        message = ACLMessage()
+        message.performative = Performative.PROPOSE
+        message.sender = self.agent_id
+        message.receiver = receiver
+        message.content = intention_triples
+        message.ontology = "https://w3id.org/fossr/ontology/bdi/"
+        
+        return message
+```
+

--- a/skills/bdi-mental-states/references/rdf-examples.md
+++ b/skills/bdi-mental-states/references/rdf-examples.md
@@ -1,0 +1,315 @@
+# BDI RDF Examples
+
+Complete RDF/Turtle examples for BDI mental state modeling.
+
+## Complete Cognitive Workflow
+
+```turtle
+@prefix bdi: <https://w3id.org/fossr/ontology/bdi/> .
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+# ============================================================
+# PHASE 1: World State Perception
+# ============================================================
+
+ex:WorldState_traffic a bdi:WorldState ;
+    rdfs:comment "Heavy traffic on Route 101" ;
+    bdi:atTime "2026-01-04T08:30:00"^^xsd:dateTime ;
+    bdi:isPerceivedBy ex:Agent_commuter ;
+    bdi:triggers ex:BeliefProcess_assess_traffic .
+
+# ============================================================
+# PHASE 2: Belief Formation
+# ============================================================
+
+ex:BeliefProcess_assess_traffic a bdi:BeliefProcess ;
+    bdi:generates ex:Belief_traffic_delay ;
+    bdi:reasonsUpon ex:WorldState_traffic ;
+    bdi:isProcessedBy ex:Agent_commuter ;
+    bdi:atTime "2026-01-04T08:31:00"^^xsd:dateTime .
+
+ex:Belief_traffic_delay a bdi:Belief ;
+    rdfs:label "Traffic will cause 30-minute delay" ;
+    bdi:refersTo ex:WorldState_traffic ;
+    bdi:hasValidity ex:TimeInterval_morning_commute ;
+    bdi:hasPart ex:Belief_route_congested , ex:Belief_delay_duration ;
+    bdi:isJustifiedBy ex:Justification_traffic_report ;
+    bdi:motivates ex:Desire_arrive_on_time .
+
+ex:Belief_route_congested a bdi:Belief ;
+    rdfs:comment "Route 101 is congested" .
+
+ex:Belief_delay_duration a bdi:Belief ;
+    rdfs:comment "Delay estimated at 30 minutes" .
+
+ex:Justification_traffic_report a bdi:Justification ;
+    rdfs:label "Real-time traffic data from navigation system" ;
+    bdi:justifies ex:Belief_traffic_delay .
+
+# ============================================================
+# PHASE 3: Desire Formation
+# ============================================================
+
+ex:DesireProcess_plan_arrival a bdi:DesireProcess ;
+    bdi:generates ex:Desire_arrive_on_time ;
+    bdi:reasonsUpon ex:Belief_traffic_delay ;
+    bdi:isProcessedBy ex:Agent_commuter .
+
+ex:Desire_arrive_on_time a bdi:Desire ;
+    rdfs:label "I desire to arrive at work on time" ;
+    bdi:isMotivatedBy ex:Belief_traffic_delay ;
+    bdi:refersTo ex:WorldState_on_time_arrival .
+
+# ============================================================
+# PHASE 4: Intention Commitment
+# ============================================================
+
+ex:IntentionProcess_commit_route a bdi:IntentionProcess ;
+    bdi:generates ex:Intention_take_alternate_route ;
+    bdi:reasonsUpon ex:Desire_arrive_on_time ;
+    bdi:isProcessedBy ex:Agent_commuter .
+
+ex:Intention_take_alternate_route a bdi:Intention ;
+    rdfs:label "I will take alternate route via Highway 280" ;
+    bdi:fulfils ex:Desire_arrive_on_time ;
+    bdi:isSupportedBy ex:Belief_traffic_delay ;
+    bdi:specifies ex:Plan_alternate_commute ;
+    bdi:isJustifiedBy ex:Justification_time_optimization .
+
+ex:Justification_time_optimization a bdi:Justification ;
+    rdfs:label "Alternate route saves 20 minutes based on current conditions" ;
+    bdi:justifies ex:Intention_take_alternate_route .
+
+# ============================================================
+# PHASE 5: Planning
+# ============================================================
+
+ex:Planning_route_selection a bdi:Planning ;
+    bdi:reasonsUpon ex:Intention_take_alternate_route ;
+    bdi:defines ex:Plan_alternate_commute ;
+    bdi:atTime ex:TimeInterval_planning_phase .
+
+ex:Plan_alternate_commute a bdi:Plan ;
+    rdfs:label "Alternate commute via Highway 280" ;
+    bdi:addresses ex:Goal_arrive_by_9am ;
+    bdi:beginsWith ex:Task_exit_Route101 ;
+    bdi:endsWith ex:Task_arrive_parking ;
+    bdi:hasComponent ex:Task_exit_Route101 , ex:Task_merge_280 , 
+                     ex:Task_navigate_280 , ex:Task_arrive_parking .
+
+ex:Task_exit_Route101 a bdi:Task ;
+    rdfs:label "Exit Route 101 at Whipple Ave" ;
+    bdi:precedes ex:Task_merge_280 .
+
+ex:Task_merge_280 a bdi:Task ;
+    rdfs:label "Merge onto Highway 280 North" ;
+    bdi:precedes ex:Task_navigate_280 .
+
+ex:Task_navigate_280 a bdi:Task ;
+    rdfs:label "Continue on Highway 280 for 8 miles" ;
+    bdi:precedes ex:Task_arrive_parking .
+
+ex:Task_arrive_parking a bdi:Task ;
+    rdfs:label "Arrive at office parking garage" .
+
+ex:Goal_arrive_by_9am a bdi:Goal ;
+    rdfs:label "Arrive at work by 9:00 AM" .
+
+# ============================================================
+# PHASE 6: Plan Execution
+# ============================================================
+
+ex:PlanExecution_commute a bdi:PlanExecution ;
+    bdi:satisfies ex:Plan_alternate_commute ;
+    bdi:addresses ex:Goal_arrive_by_9am ;
+    bdi:isExecutedBy ex:Agent_commuter ;
+    bdi:hasComponent ex:Action_exit , ex:Action_merge , 
+                     ex:Action_drive_280 , ex:Action_park ;
+    bdi:atTime ex:TimeInterval_execution ;
+    bdi:bringsAbout ex:WorldState_arrived_on_time .
+
+ex:Action_exit a bdi:Action ;
+    bdi:isExecutionOf ex:Task_exit_Route101 ;
+    bdi:isPerformedBy ex:Agent_commuter ;
+    bdi:atTime "2026-01-04T08:35:00"^^xsd:dateTime .
+
+ex:Action_merge a bdi:Action ;
+    bdi:isExecutionOf ex:Task_merge_280 ;
+    bdi:isPerformedBy ex:Agent_commuter ;
+    bdi:atTime "2026-01-04T08:37:00"^^xsd:dateTime .
+
+ex:Action_drive_280 a bdi:Action ;
+    bdi:isExecutionOf ex:Task_navigate_280 ;
+    bdi:isPerformedBy ex:Agent_commuter ;
+    bdi:atTime "2026-01-04T08:40:00"^^xsd:dateTime .
+
+ex:Action_park a bdi:Action ;
+    bdi:isExecutionOf ex:Task_arrive_parking ;
+    bdi:isPerformedBy ex:Agent_commuter ;
+    bdi:bringsAbout ex:WorldState_arrived_on_time ;
+    bdi:atTime "2026-01-04T08:52:00"^^xsd:dateTime .
+
+# ============================================================
+# PHASE 7: Resulting World State
+# ============================================================
+
+ex:WorldState_arrived_on_time a bdi:WorldState ;
+    rdfs:comment "Agent arrived at work at 8:52 AM" ;
+    bdi:atTime "2026-01-04T08:52:00"^^xsd:dateTime .
+
+# ============================================================
+# TEMPORAL INTERVALS
+# ============================================================
+
+ex:TimeInterval_morning_commute a bdi:TimeInterval ;
+    bdi:hasStartTime "2026-01-04T08:30:00"^^xsd:dateTime ;
+    bdi:hasEndTime "2026-01-04T09:00:00"^^xsd:dateTime .
+
+ex:TimeInterval_planning_phase a bdi:TimeInterval ;
+    bdi:hasStartTime "2026-01-04T08:31:00"^^xsd:dateTime ;
+    bdi:hasEndTime "2026-01-04T08:34:00"^^xsd:dateTime .
+
+ex:TimeInterval_execution a bdi:TimeInterval ;
+    bdi:hasStartTime "2026-01-04T08:35:00"^^xsd:dateTime ;
+    bdi:hasEndTime "2026-01-04T08:52:00"^^xsd:dateTime .
+```
+
+## Multi-Agent Coordination Example
+
+```turtle
+@prefix bdi: <https://w3id.org/fossr/ontology/bdi/> .
+@prefix ex: <http://example.org/> .
+@prefix fipa: <http://www.fipa.org/specs/fipa00061/> .
+
+# Shared belief about project deadline
+ex:Agent_developer a bdi:Agent ;
+    bdi:hasMentalState ex:Belief_deadline_friday .
+
+ex:Agent_manager a bdi:Agent ;
+    bdi:hasMentalState ex:Belief_deadline_friday .
+
+ex:Belief_deadline_friday a bdi:Belief ;
+    rdfs:label "Project deadline is Friday 5 PM" ;
+    bdi:refersTo ex:WorldState_deadline ;
+    bdi:hasValidity ex:TimeInterval_project_week .
+
+ex:WorldState_deadline a bdi:WorldState ;
+    rdfs:comment "Project XYZ must be delivered by 2026-01-10T17:00:00" .
+
+# Agent-specific mental states
+ex:Agent_developer 
+    bdi:hasDesire ex:Desire_complete_coding ;
+    bdi:hasIntention ex:Intention_implement_features .
+
+ex:Desire_complete_coding a bdi:Desire ;
+    rdfs:label "Complete feature implementation" ;
+    bdi:isMotivatedBy ex:Belief_deadline_friday .
+
+ex:Intention_implement_features a bdi:Intention ;
+    rdfs:label "Implement features A, B, and C" ;
+    bdi:fulfils ex:Desire_complete_coding ;
+    bdi:specifies ex:Plan_development .
+
+ex:Agent_manager 
+    bdi:hasDesire ex:Desire_ensure_delivery ;
+    bdi:hasIntention ex:Intention_coordinate_team .
+
+ex:Desire_ensure_delivery a bdi:Desire ;
+    rdfs:label "Ensure on-time project delivery" ;
+    bdi:isMotivatedBy ex:Belief_deadline_friday .
+
+ex:Intention_coordinate_team a bdi:Intention ;
+    rdfs:label "Coordinate team activities" ;
+    bdi:fulfils ex:Desire_ensure_delivery ;
+    bdi:specifies ex:Plan_project_management .
+
+# FIPA communication
+ex:Message_M1 a fipa:ACLMessage ;
+    fipa:sender ex:Agent_manager ;
+    fipa:receiver ex:Agent_developer ;
+    fipa:content ex:Belief_deadline_friday ;
+    fipa:performative fipa:inform .
+```
+
+## Conflict Resolution Example
+
+```turtle
+@prefix bdi: <https://w3id.org/fossr/ontology/bdi/> .
+@prefix ex: <http://example.org/> .
+
+# Conflicting location beliefs
+ex:Belief_at_home a bdi:Belief ;
+    bdi:refersTo ex:WorldState_home ;
+    rdfs:comment "Agent is currently at home" .
+
+ex:Belief_at_office a bdi:Belief ;
+    bdi:refersTo ex:WorldState_office ;
+    rdfs:comment "Agent is at office" .
+
+# Conflicting intentions
+ex:Intention_work_from_home a bdi:Intention ;
+    bdi:isSupportedBy ex:Belief_at_home ;
+    rdfs:label "Work from home today" .
+
+ex:Intention_attend_meeting a bdi:Intention ;
+    bdi:isSupportedBy ex:Belief_at_office ;
+    rdfs:label "Attend in-person meeting" .
+
+# Justification for conflict resolution
+ex:Justification_location_conflict a bdi:Justification ;
+    rdfs:comment "Cannot simultaneously be at home and office" ;
+    bdi:justifies ex:Intention_resolution .
+
+# Resolved intention
+ex:Intention_resolution a bdi:Intention ;
+    rdfs:label "Attend meeting via video call from home" ;
+    bdi:fulfils ex:Desire_meeting_participation ;
+    bdi:isSupportedBy ex:Belief_at_home ;
+    bdi:isJustifiedBy ex:Justification_location_conflict .
+```
+
+## T2B2T Payment Processing Example
+
+```turtle
+@prefix bdi: <https://w3id.org/fossr/ontology/bdi/> .
+@prefix ex: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# PHASE 1: Triples-to-Beliefs (External RDF → Internal Mental State)
+
+ex:WorldState_notification a bdi:WorldState ;
+    rdfs:comment "Push notification: Ghadeh requested $250 via Zelle" ;
+    bdi:atTime "2025-10-27T10:15:00"^^xsd:dateTime ;
+    bdi:triggers ex:BeliefProcess_BP1 .
+
+ex:BeliefProcess_BP1 a bdi:BeliefProcess ;
+    bdi:generates ex:Belief_payment_request ;
+    bdi:isProcessedBy ex:Agent_A .
+
+ex:Belief_payment_request a bdi:Belief ;
+    rdfs:label "Ghadeh requested $250" ;
+    bdi:refersTo ex:WorldState_notification ;
+    bdi:motivates ex:Desire_pay_Ghadeh .
+
+ex:Desire_pay_Ghadeh a bdi:Desire ;
+    rdfs:label "Pay Ghadeh $250" ;
+    bdi:isMotivatedBy ex:Belief_payment_request .
+
+ex:Intention_I1 a bdi:Intention ;
+    rdfs:label "Pay Ghadeh $250" ;
+    bdi:fulfils ex:Desire_pay_Ghadeh ;
+    bdi:specifies ex:Plan_payment .
+
+# PHASE 2: Beliefs-to-Triples (Mental State → External RDF)
+
+ex:PlanExecution_PE1 a bdi:PlanExecution ;
+    bdi:satisfies ex:Plan_payment ;
+    bdi:bringsAbout ex:WorldState_payment_complete .
+
+ex:WorldState_payment_complete a bdi:WorldState ;
+    rdfs:comment "Payment of $250 sent to Ghadeh via Zelle" ;
+    bdi:atTime "2025-10-27T10:20:00"^^xsd:dateTime .
+```
+

--- a/skills/bdi-mental-states/references/sparql-competency.md
+++ b/skills/bdi-mental-states/references/sparql-competency.md
@@ -1,0 +1,420 @@
+# SPARQL Competency Queries
+
+Validation queries for BDI ontology implementations based on competency questions.
+
+## Mental Entity Queries
+
+### CQ1: What are all mental entities?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?entity ?type WHERE {
+    ?entity rdf:type ?type .
+    ?type rdfs:subClassOf* bdi:MentalEntity .
+}
+```
+
+### CQ2: What beliefs does an agent hold?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief ?label WHERE {
+    ?agent bdi:hasMentalState ?belief .
+    ?belief a bdi:Belief .
+    OPTIONAL { ?belief rdfs:label ?label }
+}
+```
+
+### CQ3: What desires does an agent have?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?desire ?label WHERE {
+    ?agent bdi:hasDesire ?desire .
+    ?desire a bdi:Desire .
+    OPTIONAL { ?desire rdfs:label ?label }
+}
+```
+
+### CQ4: What intentions has an agent committed to?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?intention ?label WHERE {
+    ?agent bdi:hasIntention ?intention .
+    ?intention a bdi:Intention .
+    OPTIONAL { ?intention rdfs:label ?label }
+}
+```
+
+## Motivational Chain Queries
+
+### CQ5: What beliefs motivated formation of a given desire?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief ?beliefLabel WHERE {
+    ?desire bdi:isMotivatedBy ?belief .
+    ?belief a bdi:Belief .
+    OPTIONAL { ?belief rdfs:label ?beliefLabel }
+}
+```
+
+### CQ6: Which desire does a particular intention fulfill?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?desire ?desireLabel WHERE {
+    ?intention bdi:fulfils ?desire .
+    ?desire a bdi:Desire .
+    OPTIONAL { ?desire rdfs:label ?desireLabel }
+}
+```
+
+### CQ7: What beliefs support a given intention?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief ?label WHERE {
+    ?intention bdi:isSupportedBy ?belief .
+    ?belief a bdi:Belief .
+    OPTIONAL { ?belief rdfs:label ?label }
+}
+```
+
+### CQ8: Trace complete cognitive chain for an intention
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?intention ?desire ?belief ?worldState WHERE {
+    ?intention a bdi:Intention ;
+               bdi:fulfils ?desire ;
+               bdi:isSupportedBy ?belief .
+    ?desire bdi:isMotivatedBy ?belief .
+    ?belief bdi:refersTo ?worldState .
+}
+```
+
+## Mental Process Queries
+
+### CQ9: Which mental process generated a belief?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?process ?processType WHERE {
+    ?process bdi:generates ?belief .
+    ?belief a bdi:Belief .
+    ?process a ?processType .
+    FILTER(?processType != owl:NamedIndividual)
+}
+```
+
+### CQ10: What triggered a mental process?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?process ?trigger ?triggerType WHERE {
+    ?process a bdi:MentalProcess ;
+             bdi:isTriggeredBy ?trigger .
+    ?trigger a ?triggerType .
+}
+```
+
+### CQ11: What did a mental process reason upon?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?process ?input WHERE {
+    ?process a bdi:MentalProcess ;
+             bdi:reasonsUpon ?input .
+}
+```
+
+## Plan and Goal Queries
+
+### CQ12: What plan does an intention specify?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?intention ?plan ?goal WHERE {
+    ?intention bdi:specifies ?plan .
+    ?plan a bdi:Plan ;
+          bdi:addresses ?goal .
+}
+```
+
+### CQ13: What is the ordered sequence of tasks in a plan?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?plan ?task ?nextTask WHERE {
+    ?plan a bdi:Plan ;
+          bdi:hasComponent ?task .
+    OPTIONAL { ?task bdi:precedes ?nextTask }
+}
+ORDER BY ?task
+```
+
+### CQ14: What is the first and last task of a plan?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?plan ?firstTask ?lastTask WHERE {
+    ?plan a bdi:Plan ;
+          bdi:beginsWith ?firstTask ;
+          bdi:endsWith ?lastTask .
+}
+```
+
+### CQ15: Which actions executed which tasks?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?action ?task ?time WHERE {
+    ?action bdi:isExecutionOf ?task ;
+            bdi:atTime ?time .
+}
+ORDER BY ?time
+```
+
+## Temporal Queries
+
+### CQ16: What mental states are valid at a specific time?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?mentalState ?type WHERE {
+    ?mentalState bdi:hasValidity ?interval .
+    ?interval bdi:hasStartTime ?start ;
+              bdi:hasEndTime ?end .
+    ?mentalState a ?type .
+    FILTER(?start <= "2026-01-04T10:00:00"^^xsd:dateTime && 
+           ?end >= "2026-01-04T10:00:00"^^xsd:dateTime)
+}
+```
+
+### CQ17: When was a belief formed?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief ?formationTime WHERE {
+    ?process bdi:generates ?belief ;
+             bdi:atTime ?formationTime .
+    ?belief a bdi:Belief .
+}
+```
+
+### CQ18: What is the temporal validity of an intention?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?intention ?start ?end WHERE {
+    ?intention a bdi:Intention ;
+               bdi:hasValidity ?interval .
+    ?interval bdi:hasStartTime ?start ;
+              bdi:hasEndTime ?end .
+}
+```
+
+## Justification Queries
+
+### CQ19: What justifies a belief?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief ?justification ?justLabel WHERE {
+    ?belief a bdi:Belief ;
+            bdi:isJustifiedBy ?justification .
+    OPTIONAL { ?justification rdfs:label ?justLabel }
+}
+```
+
+### CQ20: What justifies an intention?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?intention ?justification ?justLabel WHERE {
+    ?intention a bdi:Intention ;
+               bdi:isJustifiedBy ?justification .
+    OPTIONAL { ?justification rdfs:label ?justLabel }
+}
+```
+
+## Compositional Queries
+
+### CQ21: What parts comprise a complex belief?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief ?part ?partLabel WHERE {
+    ?belief a bdi:Belief ;
+            bdi:hasPart ?part .
+    OPTIONAL { ?part rdfs:label ?partLabel }
+}
+```
+
+### CQ22: Find composite mental entities
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?composite (COUNT(?part) AS ?partCount) WHERE {
+    ?composite bdi:hasPart ?part .
+}
+GROUP BY ?composite
+HAVING (COUNT(?part) > 1)
+```
+
+## World State Queries
+
+### CQ23: What world state does a belief refer to?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief ?worldState ?wsComment WHERE {
+    ?belief a bdi:Belief ;
+            bdi:refersTo ?worldState .
+    OPTIONAL { ?worldState rdfs:comment ?wsComment }
+}
+```
+
+### CQ24: What actions brought about a world state?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?action ?worldState WHERE {
+    ?action bdi:bringsAbout ?worldState .
+    ?worldState a bdi:WorldState .
+}
+```
+
+### CQ25: What world states has an agent perceived?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?agent ?worldState ?time WHERE {
+    ?agent bdi:perceives ?worldState .
+    OPTIONAL { ?worldState bdi:atTime ?time }
+}
+```
+
+## Validation Queries (OWLUnit Style)
+
+### V1: Every intention must fulfill exactly one desire
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?intention WHERE {
+    ?intention a bdi:Intention .
+    FILTER NOT EXISTS { ?intention bdi:fulfils ?desire }
+}
+# Expected: Empty result set
+```
+
+### V2: Every belief must reference a world state
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief WHERE {
+    ?belief a bdi:Belief .
+    FILTER NOT EXISTS { ?belief bdi:refersTo ?worldState }
+}
+# Expected: Empty result set (or only abstract beliefs)
+```
+
+### V3: Mental processes must reason upon something
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?process WHERE {
+    ?process a bdi:MentalProcess .
+    FILTER NOT EXISTS { ?process bdi:reasonsUpon ?input }
+}
+# Expected: Empty result set
+```
+
+### V4: BeliefProcess must generate only Beliefs
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?process ?generated WHERE {
+    ?process a bdi:BeliefProcess ;
+             bdi:generates ?generated .
+    FILTER NOT EXISTS { ?generated a bdi:Belief }
+}
+# Expected: Empty result set
+```
+
+### V5: Plans must have begin and end tasks
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?plan WHERE {
+    ?plan a bdi:Plan .
+    FILTER NOT EXISTS { 
+        ?plan bdi:beginsWith ?first ;
+              bdi:endsWith ?last 
+    }
+}
+# Expected: Empty result set
+```
+
+## Multi-Agent Queries
+
+### CQ26: What beliefs are shared across agents?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?belief (COUNT(DISTINCT ?agent) AS ?agentCount) WHERE {
+    ?agent bdi:hasMentalState ?belief .
+    ?belief a bdi:Belief .
+}
+GROUP BY ?belief
+HAVING (COUNT(DISTINCT ?agent) > 1)
+```
+
+### CQ27: Which agents share the same desire?
+
+```sparql
+PREFIX bdi: <https://w3id.org/fossr/ontology/bdi/>
+
+SELECT ?desire ?agent1 ?agent2 WHERE {
+    ?agent1 bdi:hasDesire ?desire .
+    ?agent2 bdi:hasDesire ?desire .
+    FILTER(?agent1 != ?agent2)
+}
+```
+


### PR DESCRIPTION
Add new skill for transforming external context into formal agent mental states using Belief-Desire-Intention (BDI) ontology patterns.

## New Skill: bdi-mental-states

Enables agents to reason about context through cognitive architecture:
- Transform RDF context into beliefs, desires, intentions
- T2B2T paradigm (Triples-to-Beliefs-to-Triples)
- Temporal validity tracking for belief expiration
- Justification chains for explainable reasoning
- Multi-agent mental state coordination

## Reference Documents
- bdi-ontology-core.md: Class hierarchy, properties, DOLCE alignment
- rdf-examples.md: Complete Turtle examples for cognitive workflows
- sparql-competency.md: 27 SPARQL validation queries
- framework-integration.md: SEMAS, LAG, JADE/JADEX integration patterns

## Plugin Registration
- Added cognitive-architecture plugin group to marketplace.json

Based on Zuppiroli et al. 'The Belief-Desire-Intention Ontology' (2025)