### PR TITLE
feat: add filesystem-context skill for dynamic context discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,13 +23,14 @@
     },
     {
       "name": "agent-architecture",
-      "description": "Multi-agent patterns, memory systems, and tool design for building production AI agent architectures",
+      "description": "Multi-agent patterns, memory systems, tool design, and filesystem-based context for building production AI agent architectures",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/multi-agent-patterns",
         "./skills/memory-systems",
-        "./skills/tool-design"
+        "./skills/tool-design",
+        "./skills/filesystem-context"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ These skills cover the patterns and structures for building effective agent syst
 | [multi-agent-patterns](skills/multi-agent-patterns/) | Master orchestrator, peer-to-peer, and hierarchical multi-agent architectures |
 | [memory-systems](skills/memory-systems/) | Design short-term, long-term, and graph-based memory architectures |
 | [tool-design](skills/tool-design/) | Build tools that agents can use effectively |
+| [filesystem-context](skills/filesystem-context/) | **NEW** Use filesystems for dynamic context discovery, tool output offloading, and plan persistence |
 
 ### Operational Skills
 
@@ -109,7 +110,7 @@ Option B - Direct install via command:
 | Plugin | Skills Included |
 |--------|-----------------|
 | `context-engineering-fundamentals` | context-fundamentals, context-degradation, context-compression, context-optimization |
-| `agent-architecture` | multi-agent-patterns, memory-systems, tool-design |
+| `agent-architecture` | multi-agent-patterns, memory-systems, tool-design, filesystem-context |
 | `agent-evaluation` | evaluation, advanced-evaluation |
 | `agent-development` | project-development |
 | `cognitive-architecture` | bdi-mental-states |
@@ -125,6 +126,7 @@ Option B - Direct install via command:
 | `multi-agent-patterns` | "design multi-agent system", "implement supervisor pattern" |
 | `memory-systems` | "implement agent memory", "build knowledge graph", "track entities" |
 | `tool-design` | "design agent tools", "reduce tool complexity", "implement MCP tools" |
+| `filesystem-context` | "offload context to files", "dynamic context discovery", "agent scratch pad", "file-based context" |
 | `evaluation` | "evaluate agent performance", "build test framework", "measure quality" |
 | `advanced-evaluation` | "implement LLM-as-judge", "compare model outputs", "mitigate bias" |
 | `project-development` | "start LLM project", "design batch pipeline", "evaluate task-model fit" |

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,6 +35,9 @@ Production multi-agent systems converge on three dominant patterns: supervisor/o
 **Memory System Design**
 Memory architectures range from simple scratchpads to sophisticated temporal knowledge graphs. Vector RAG provides semantic retrieval but loses relationship information. Knowledge graphs preserve structure but require more engineering investment. The file-system-as-memory pattern enables just-in-time context loading without stuffing context windows.
 
+**Filesystem-Based Context**
+The filesystem provides a single interface for storing, retrieving, and updating effectively unlimited context. Key patterns include scratch pads for tool output offloading, plan persistence for long-horizon tasks, sub-agent communication via shared files, and dynamic skill loading. Agents use `ls`, `glob`, `grep`, and `read_file` for targeted context discovery, often outperforming semantic search for structural queries.
+
 **Tool Design Principles**
 Tools are contracts between deterministic systems and non-deterministic agents. Effective tool design follows the consolidation principle (prefer single comprehensive tools over multiple narrow ones), returns contextual information in errors, supports response format options for token efficiency, and uses clear namespacing.
 
@@ -77,6 +80,7 @@ Internal skills in this collection:
 - [multi-agent-patterns](skills/multi-agent-patterns/SKILL.md)
 - [memory-systems](skills/memory-systems/SKILL.md)
 - [tool-design](skills/tool-design/SKILL.md)
+- [filesystem-context](skills/filesystem-context/SKILL.md)
 - [context-optimization](skills/context-optimization/SKILL.md)
 - [evaluation](skills/evaluation/SKILL.md)
 - [project-development](skills/project-development/SKILL.md)

--- a/skills/filesystem-context/SKILL.md
+++ b/skills/filesystem-context/SKILL.md
@@ -1,0 +1,321 @@
+---
+name: filesystem-context
+description: This skill should be used when the user asks to "offload context to files", "implement dynamic context discovery", "use filesystem for agent memory", "reduce context window bloat", or mentions file-based context management, tool output persistence, agent scratch pads, or just-in-time context loading.
+---
+
+# Filesystem-Based Context Engineering
+
+The filesystem provides a single interface through which agents can flexibly store, retrieve, and update an effectively unlimited amount of context. This pattern addresses the fundamental constraint that context windows are limited while tasks often require more information than fits in a single window.
+
+The core insight is that files enable dynamic context discovery: agents pull relevant context on demand rather than carrying everything in the context window. This contrasts with static context, which is always included regardless of relevance.
+
+## When to Activate
+
+Activate this skill when:
+- Tool outputs are bloating the context window
+- Agents need to persist state across long trajectories
+- Sub-agents must share information without direct message passing
+- Tasks require more context than fits in the window
+- Building agents that learn and update their own instructions
+- Implementing scratch pads for intermediate results
+- Terminal outputs or logs need to be accessible to agents
+
+## Core Concepts
+
+Context engineering can fail in four predictable ways. First, when the context an agent needs is not in the total available context. Second, when retrieved context fails to encapsulate needed context. Third, when retrieved context far exceeds needed context, wasting tokens and degrading performance. Fourth, when agents cannot discover niche information buried in many files.
+
+The filesystem addresses these failures by providing a persistent layer where agents write once and read selectively, offloading bulk content while preserving the ability to retrieve specific information through search tools.
+
+## Detailed Topics
+
+### The Static vs Dynamic Context Trade-off
+
+**Static Context**
+Static context is always included in the prompt: system instructions, tool definitions, and critical rules. Static context consumes tokens regardless of task relevance. As agents accumulate more capabilities (tools, skills, instructions), static context grows and crowds out space for dynamic information.
+
+**Dynamic Context Discovery**
+Dynamic context is loaded on-demand when relevant to the current task. The agent receives minimal static pointers (names, descriptions, file paths) and uses search tools to load full content when needed.
+
+Dynamic discovery is more token-efficient because only necessary data enters the context window. It can also improve response quality by reducing potentially confusing or contradictory information.
+
+The trade-off: dynamic discovery requires the model to correctly identify when to load additional context. This works well with current frontier models but may fail with less capable models that do not recognize when they need more information.
+
+### Pattern 1: Filesystem as Scratch Pad
+
+**The Problem**
+Tool calls can return massive outputs. A web search may return 10k tokens of raw content. A database query may return hundreds of rows. If this content enters the message history, it remains for the entire conversation, inflating token costs and potentially degrading attention to more relevant information.
+
+**The Solution**
+Write large tool outputs to files instead of returning them directly to the context. The agent then uses targeted retrieval (grep, line-specific reads) to extract only the relevant portions.
+
+**Implementation**
+```python
+def handle_tool_output(output: str, threshold: int = 2000) -> str:
+    if len(output) < threshold:
+        return output
+    
+    # Write to scratch pad
+    file_path = f"scratch/{tool_name}_{timestamp}.txt"
+    write_file(file_path, output)
+    
+    # Return reference instead of content
+    key_summary = extract_summary(output, max_tokens=200)
+    return f"[Output written to {file_path}. Summary: {key_summary}]"
+```
+
+The agent can then use `grep` to search for specific patterns or `read_file` with line ranges to retrieve targeted sections.
+
+**Benefits**
+- Reduces token accumulation over long conversations
+- Preserves full output for later reference
+- Enables targeted retrieval instead of carrying everything
+
+### Pattern 2: Plan Persistence
+
+**The Problem**
+Long-horizon tasks require agents to make plans and follow them. But as conversations extend, plans can fall out of attention or be lost to summarization. The agent loses track of what it was supposed to do.
+
+**The Solution**
+Write plans to the filesystem. The agent can re-read its plan at any point, reminding itself of the current objective and progress. This is sometimes called "manipulating attention through recitation."
+
+**Implementation**
+Store plans in structured format:
+```yaml
+# scratch/current_plan.yaml
+objective: "Refactor authentication module"
+status: in_progress
+steps:
+  - id: 1
+    description: "Audit current auth endpoints"
+    status: completed
+  - id: 2
+    description: "Design new token validation flow"
+    status: in_progress
+  - id: 3
+    description: "Implement and test changes"
+    status: pending
+```
+
+The agent reads this file at the start of each turn or when it needs to re-orient.
+
+### Pattern 3: Sub-Agent Communication via Filesystem
+
+**The Problem**
+In multi-agent systems, sub-agents typically report findings to a coordinator agent through message passing. This creates a "game of telephone" where information degrades through summarization at each hop.
+
+**The Solution**
+Sub-agents write their findings directly to the filesystem. The coordinator reads these files directly, bypassing intermediate message passing. This preserves fidelity and reduces context accumulation in the coordinator.
+
+**Implementation**
+```
+workspace/
+  agents/
+    research_agent/
+      findings.md        # Research agent writes here
+      sources.jsonl      # Source tracking
+    code_agent/
+      changes.md         # Code agent writes here
+      test_results.txt   # Test output
+  coordinator/
+    synthesis.md         # Coordinator reads agent outputs, writes synthesis
+```
+
+Each agent operates in relative isolation but shares state through the filesystem.
+
+### Pattern 4: Dynamic Skill Loading
+
+**The Problem**
+Agents may have many skills or instruction sets, but most are irrelevant to any given task. Stuffing all instructions into the system prompt wastes tokens and can confuse the model with contradictory or irrelevant guidance.
+
+**The Solution**
+Store skills as files. Include only skill names and brief descriptions in static context. The agent uses search tools to load relevant skill content when the task requires it.
+
+**Implementation**
+Static context includes:
+```
+Available skills (load with read_file when relevant):
+- database-optimization: Query tuning and indexing strategies
+- api-design: REST/GraphQL best practices
+- testing-strategies: Unit, integration, and e2e testing patterns
+```
+
+Agent loads `skills/database-optimization/SKILL.md` only when working on database tasks.
+
+### Pattern 5: Terminal and Log Persistence
+
+**The Problem**
+Terminal output from long-running processes accumulates rapidly. Copying and pasting output into agent input is manual and inefficient.
+
+**The Solution**
+Sync terminal output to files automatically. The agent can then grep for relevant sections (error messages, specific commands) without loading entire terminal histories.
+
+**Implementation**
+Terminal sessions are persisted as files:
+```
+terminals/
+  1.txt    # Terminal session 1 output
+  2.txt    # Terminal session 2 output
+```
+
+Agents query with targeted grep:
+```bash
+grep -A 5 "error" terminals/1.txt
+```
+
+### Pattern 6: Learning Through Self-Modification
+
+**The Problem**
+Agents often lack context that users provide implicitly or explicitly during interactions. Traditionally, this requires manual system prompt updates between sessions.
+
+**The Solution**
+Agents write learned information to their own instruction files. Subsequent sessions load these files, incorporating learned context automatically.
+
+**Implementation**
+After user provides preference:
+```python
+def remember_preference(key: str, value: str):
+    preferences_file = "agent/user_preferences.yaml"
+    prefs = load_yaml(preferences_file)
+    prefs[key] = value
+    write_yaml(preferences_file, prefs)
+```
+
+Subsequent sessions include a step to load user preferences if the file exists.
+
+**Caution**
+This pattern is still emerging. Self-modification requires careful guardrails to prevent agents from accumulating incorrect or contradictory instructions over time.
+
+### Filesystem Search Techniques
+
+Models are specifically trained to understand filesystem traversal. The combination of `ls`, `glob`, `grep`, and `read_file` with line ranges provides powerful context discovery:
+
+- `ls` / `list_dir`: Discover directory structure
+- `glob`: Find files matching patterns (e.g., `**/*.py`)
+- `grep`: Search file contents for patterns, returns matching lines
+- `read_file` with ranges: Read specific line ranges without loading entire files
+
+This combination often outperforms semantic search for technical content (code, API docs) where semantic meaning is sparse but structural patterns are clear.
+
+Semantic search and filesystem search work well together: semantic search for conceptual queries, filesystem search for structural and exact-match queries.
+
+## Practical Guidance
+
+### When to Use Filesystem Context
+
+**Use filesystem patterns when:**
+- Tool outputs exceed 2000 tokens
+- Tasks span multiple conversation turns
+- Multiple agents need to share state
+- Skills or instructions exceed what fits comfortably in system prompt
+- Logs or terminal output need selective querying
+
+**Avoid filesystem patterns when:**
+- Tasks complete in single turns
+- Context fits comfortably in window
+- Latency is critical (file I/O adds overhead)
+- Simple model incapable of filesystem tool use
+
+### File Organization
+
+Structure files for discoverability:
+```
+project/
+  scratch/           # Temporary working files
+    tool_outputs/    # Large tool results
+    plans/           # Active plans and checklists
+  memory/            # Persistent learned information
+    preferences.yaml # User preferences
+    patterns.md      # Learned patterns
+  skills/            # Loadable skill definitions
+  agents/            # Sub-agent workspaces
+```
+
+Use consistent naming conventions. Include timestamps or IDs in scratch files for disambiguation.
+
+### Token Accounting
+
+Track where tokens originate:
+- Measure static vs dynamic context ratio
+- Monitor tool output sizes before and after offloading
+- Track how often dynamic context is actually loaded
+
+Optimize based on measurements, not assumptions.
+
+## Examples
+
+**Example 1: Tool Output Offloading**
+```
+Input: Web search returns 8000 tokens
+Before: 8000 tokens added to message history
+After: 
+  - Write to scratch/search_results_001.txt
+  - Return: "[Results in scratch/search_results_001.txt. Key finding: API rate limit is 1000 req/min]"
+  - Agent greps file when needing specific details
+Result: ~100 tokens in context, 8000 tokens accessible on demand
+```
+
+**Example 2: Dynamic Skill Loading**
+```
+Input: User asks about database indexing
+Static context: "database-optimization: Query tuning and indexing"
+Agent action: read_file("skills/database-optimization/SKILL.md")
+Result: Full skill loaded only when relevant
+```
+
+**Example 3: Chat History as File Reference**
+```
+Trigger: Context window limit reached, summarization required
+Action: 
+  1. Write full history to history/session_001.txt
+  2. Generate summary for new context window
+  3. Include reference: "Full history in history/session_001.txt"
+Result: Agent can search history file to recover details lost in summarization
+```
+
+## Guidelines
+
+1. Write large outputs to files; return summaries and references to context
+2. Store plans and state in structured files for re-reading
+3. Use sub-agent file workspaces instead of message chains
+4. Load skills dynamically rather than stuffing all into system prompt
+5. Persist terminal and log output as searchable files
+6. Combine grep/glob with semantic search for comprehensive discovery
+7. Organize files for agent discoverability with clear naming
+8. Measure token savings to validate filesystem patterns are effective
+9. Implement cleanup for scratch files to prevent unbounded growth
+10. Guard self-modification patterns with validation
+
+## Integration
+
+This skill connects to:
+
+- context-optimization - Filesystem offloading is a form of observation masking
+- memory-systems - Filesystem-as-memory is a simple memory layer
+- multi-agent-patterns - Sub-agent file workspaces enable isolation
+- context-compression - File references enable lossless "compression"
+- tool-design - Tools should return file references for large outputs
+
+## References
+
+Internal reference:
+- [Implementation Patterns](./references/implementation-patterns.md) - Detailed pattern implementations
+
+Related skills in this collection:
+- context-optimization - Token reduction techniques
+- memory-systems - Persistent storage patterns
+- multi-agent-patterns - Agent coordination
+
+External resources:
+- LangChain Deep Agents: How agents can use filesystems for context engineering
+- Cursor: Dynamic context discovery patterns
+- Anthropic: Agent Skills specification
+
+---
+
+## Skill Metadata
+
+**Created**: 2026-01-07
+**Last Updated**: 2026-01-07
+**Author**: Agent Skills for Context Engineering Contributors
+**Version**: 1.0.0
+

--- a/skills/filesystem-context/references/implementation-patterns.md
+++ b/skills/filesystem-context/references/implementation-patterns.md
@@ -1,0 +1,549 @@
+# Filesystem Context Implementation Patterns
+
+This reference provides detailed implementation patterns for filesystem-based context engineering.
+
+## Pattern Catalog
+
+### 1. Scratch Pad Manager
+
+A centralized manager for handling large tool outputs and intermediate results.
+
+```python
+import os
+import json
+from datetime import datetime
+from pathlib import Path
+
+class ScratchPadManager:
+    """Manages temporary file storage for agent context offloading."""
+    
+    def __init__(self, base_path: str = "scratch", token_threshold: int = 2000):
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.token_threshold = token_threshold
+        self.manifest = {}
+    
+    def should_offload(self, content: str) -> bool:
+        """Determine if content exceeds threshold for offloading."""
+        # Rough token estimate: 1 token ≈ 4 characters
+        estimated_tokens = len(content) // 4
+        return estimated_tokens > self.token_threshold
+    
+    def offload(self, content: str, source: str, summary: str = None) -> dict:
+        """Write content to file, return reference."""
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"{source}_{timestamp}.txt"
+        file_path = self.base_path / filename
+        
+        file_path.write_text(content)
+        
+        reference = {
+            "type": "file_reference",
+            "path": str(file_path),
+            "source": source,
+            "timestamp": timestamp,
+            "size_chars": len(content),
+            "summary": summary or self._extract_summary(content)
+        }
+        
+        self.manifest[filename] = reference
+        return reference
+    
+    def _extract_summary(self, content: str, max_chars: int = 500) -> str:
+        """Extract first meaningful content as summary."""
+        lines = content.strip().split('\n')
+        summary_lines = []
+        char_count = 0
+        
+        for line in lines:
+            if char_count + len(line) > max_chars:
+                break
+            summary_lines.append(line)
+            char_count += len(line)
+        
+        return '\n'.join(summary_lines)
+    
+    def cleanup(self, max_age_hours: int = 24):
+        """Remove scratch files older than threshold."""
+        cutoff = datetime.now().timestamp() - (max_age_hours * 3600)
+        
+        for file_path in self.base_path.glob("*.txt"):
+            if file_path.stat().st_mtime < cutoff:
+                file_path.unlink()
+                if file_path.name in self.manifest:
+                    del self.manifest[file_path.name]
+```
+
+### 2. Plan Persistence
+
+Structured plan storage with progress tracking.
+
+```python
+import yaml
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import List, Optional
+
+class StepStatus(Enum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    BLOCKED = "blocked"
+    CANCELLED = "cancelled"
+
+@dataclass
+class PlanStep:
+    id: int
+    description: str
+    status: StepStatus = StepStatus.PENDING
+    notes: Optional[str] = None
+
+@dataclass
+class AgentPlan:
+    objective: str
+    steps: List[PlanStep] = field(default_factory=list)
+    status: str = "in_progress"
+    
+    def save(self, path: str = "scratch/current_plan.yaml"):
+        """Persist plan to filesystem."""
+        data = {
+            "objective": self.objective,
+            "status": self.status,
+            "steps": [
+                {
+                    "id": s.id,
+                    "description": s.description,
+                    "status": s.status.value,
+                    "notes": s.notes
+                }
+                for s in self.steps
+            ]
+        }
+        with open(path, 'w') as f:
+            yaml.dump(data, f, default_flow_style=False)
+    
+    @classmethod
+    def load(cls, path: str = "scratch/current_plan.yaml") -> "AgentPlan":
+        """Load plan from filesystem."""
+        with open(path, 'r') as f:
+            data = yaml.safe_load(f)
+        
+        plan = cls(objective=data["objective"], status=data.get("status", "in_progress"))
+        for step_data in data.get("steps", []):
+            plan.steps.append(PlanStep(
+                id=step_data["id"],
+                description=step_data["description"],
+                status=StepStatus(step_data["status"]),
+                notes=step_data.get("notes")
+            ))
+        return plan
+    
+    def current_step(self) -> Optional[PlanStep]:
+        """Get the first non-completed step."""
+        for step in self.steps:
+            if step.status != StepStatus.COMPLETED:
+                return step
+        return None
+    
+    def complete_step(self, step_id: int, notes: str = None):
+        """Mark step as completed."""
+        for step in self.steps:
+            if step.id == step_id:
+                step.status = StepStatus.COMPLETED
+                if notes:
+                    step.notes = notes
+                break
+```
+
+### 3. Sub-Agent Workspace
+
+File-based communication between agents.
+
+```python
+from pathlib import Path
+from datetime import datetime
+import json
+
+class AgentWorkspace:
+    """Manages file-based workspace for an agent."""
+    
+    def __init__(self, agent_id: str, base_path: str = "workspace/agents"):
+        self.agent_id = agent_id
+        self.path = Path(base_path) / agent_id
+        self.path.mkdir(parents=True, exist_ok=True)
+        
+        # Standard files
+        self.findings_file = self.path / "findings.md"
+        self.status_file = self.path / "status.json"
+        self.log_file = self.path / "activity.log"
+    
+    def write_finding(self, content: str, append: bool = True):
+        """Write or append a finding."""
+        mode = 'a' if append else 'w'
+        with open(self.findings_file, mode) as f:
+            if append:
+                f.write(f"\n---\n## {datetime.now().isoformat()}\n\n")
+            f.write(content)
+    
+    def update_status(self, status: str, progress: float = None, details: dict = None):
+        """Update agent status for coordinator visibility."""
+        status_data = {
+            "agent_id": self.agent_id,
+            "status": status,
+            "updated_at": datetime.now().isoformat(),
+            "progress": progress,
+            "details": details or {}
+        }
+        self.status_file.write_text(json.dumps(status_data, indent=2))
+    
+    def log(self, message: str):
+        """Append to activity log."""
+        with open(self.log_file, 'a') as f:
+            f.write(f"[{datetime.now().isoformat()}] {message}\n")
+    
+    def read_peer_findings(self, peer_id: str) -> str:
+        """Read findings from another agent's workspace."""
+        peer_path = self.path.parent / peer_id / "findings.md"
+        if peer_path.exists():
+            return peer_path.read_text()
+        return ""
+
+
+class CoordinatorWorkspace:
+    """Coordinator that reads from sub-agent workspaces."""
+    
+    def __init__(self, base_path: str = "workspace/agents"):
+        self.base_path = Path(base_path)
+    
+    def get_all_statuses(self) -> dict:
+        """Collect status from all sub-agents."""
+        statuses = {}
+        for agent_dir in self.base_path.iterdir():
+            if agent_dir.is_dir():
+                status_file = agent_dir / "status.json"
+                if status_file.exists():
+                    statuses[agent_dir.name] = json.loads(status_file.read_text())
+        return statuses
+    
+    def aggregate_findings(self) -> str:
+        """Combine all agent findings into synthesis."""
+        findings = []
+        for agent_dir in self.base_path.iterdir():
+            if agent_dir.is_dir():
+                findings_file = agent_dir / "findings.md"
+                if findings_file.exists():
+                    findings.append(f"# {agent_dir.name}\n\n{findings_file.read_text()}")
+        return "\n\n".join(findings)
+```
+
+### 4. Dynamic Skill Loader
+
+Load skill content on demand.
+
+```python
+from pathlib import Path
+from typing import List, Optional
+import yaml
+
+@dataclass
+class SkillMetadata:
+    name: str
+    description: str
+    path: str
+    triggers: List[str] = field(default_factory=list)
+
+class SkillLoader:
+    """Manages dynamic loading of agent skills."""
+    
+    def __init__(self, skills_path: str = "skills"):
+        self.skills_path = Path(skills_path)
+        self.skill_index = self._build_index()
+    
+    def _build_index(self) -> dict:
+        """Build index of available skills from SKILL.md frontmatter."""
+        index = {}
+        for skill_dir in self.skills_path.iterdir():
+            if skill_dir.is_dir():
+                skill_file = skill_dir / "SKILL.md"
+                if skill_file.exists():
+                    metadata = self._parse_frontmatter(skill_file)
+                    if metadata:
+                        index[metadata.name] = metadata
+        return index
+    
+    def _parse_frontmatter(self, path: Path) -> Optional[SkillMetadata]:
+        """Extract YAML frontmatter from skill file."""
+        content = path.read_text()
+        if content.startswith('---'):
+            end = content.find('---', 3)
+            if end > 0:
+                frontmatter = yaml.safe_load(content[3:end])
+                return SkillMetadata(
+                    name=frontmatter.get('name', path.parent.name),
+                    description=frontmatter.get('description', ''),
+                    path=str(path),
+                    triggers=frontmatter.get('triggers', [])
+                )
+        return None
+    
+    def get_static_context(self) -> str:
+        """Generate minimal static context listing available skills."""
+        lines = ["Available skills (load with read_file when relevant):"]
+        for name, meta in self.skill_index.items():
+            lines.append(f"- {name}: {meta.description[:100]}")
+        return "\n".join(lines)
+    
+    def load_skill(self, name: str) -> str:
+        """Load full skill content."""
+        if name in self.skill_index:
+            return Path(self.skill_index[name].path).read_text()
+        raise ValueError(f"Unknown skill: {name}")
+    
+    def find_relevant_skills(self, query: str) -> List[str]:
+        """Find skills that might be relevant to a query."""
+        query_lower = query.lower()
+        relevant = []
+        for name, meta in self.skill_index.items():
+            if any(trigger in query_lower for trigger in meta.triggers):
+                relevant.append(name)
+            elif name.replace('-', ' ') in query_lower:
+                relevant.append(name)
+        return relevant
+```
+
+### 5. Terminal Output Persistence
+
+Capture and persist terminal sessions.
+
+```python
+import subprocess
+from pathlib import Path
+from datetime import datetime
+import re
+
+class TerminalCapture:
+    """Captures and persists terminal output for agent access."""
+    
+    def __init__(self, terminals_path: str = "terminals"):
+        self.terminals_path = Path(terminals_path)
+        self.terminals_path.mkdir(parents=True, exist_ok=True)
+        self.session_counter = 0
+    
+    def run_command(self, command: str, capture: bool = True) -> dict:
+        """Run command and optionally capture output to file."""
+        self.session_counter += 1
+        
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True
+        )
+        
+        output = {
+            "command": command,
+            "exit_code": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "timestamp": datetime.now().isoformat()
+        }
+        
+        if capture:
+            output["file"] = self._persist_output(output)
+        
+        return output
+    
+    def _persist_output(self, output: dict) -> str:
+        """Write output to terminal file."""
+        filename = f"{self.session_counter}.txt"
+        file_path = self.terminals_path / filename
+        
+        content = f"""---
+command: {output['command']}
+exit_code: {output['exit_code']}
+timestamp: {output['timestamp']}
+---
+
+=== STDOUT ===
+{output['stdout']}
+
+=== STDERR ===
+{output['stderr']}
+"""
+        file_path.write_text(content)
+        return str(file_path)
+    
+    def grep_terminals(self, pattern: str, context_lines: int = 3) -> List[dict]:
+        """Search all terminal outputs for pattern."""
+        matches = []
+        regex = re.compile(pattern, re.IGNORECASE)
+        
+        for term_file in self.terminals_path.glob("*.txt"):
+            content = term_file.read_text()
+            lines = content.split('\n')
+            
+            for i, line in enumerate(lines):
+                if regex.search(line):
+                    start = max(0, i - context_lines)
+                    end = min(len(lines), i + context_lines + 1)
+                    matches.append({
+                        "file": str(term_file),
+                        "line_number": i + 1,
+                        "context": '\n'.join(lines[start:end])
+                    })
+        
+        return matches
+```
+
+### 6. Self-Modification Guard
+
+Safe pattern for agent self-learning.
+
+```python
+import yaml
+from pathlib import Path
+from datetime import datetime
+from typing import Any
+
+class PreferenceStore:
+    """Guarded storage for agent-learned preferences."""
+    
+    MAX_ENTRIES = 100
+    MAX_VALUE_LENGTH = 1000
+    
+    def __init__(self, path: str = "agent/preferences.yaml"):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.preferences = self._load()
+    
+    def _load(self) -> dict:
+        """Load preferences from file."""
+        if self.path.exists():
+            return yaml.safe_load(self.path.read_text()) or {}
+        return {}
+    
+    def _save(self):
+        """Persist preferences to file."""
+        self.path.write_text(yaml.dump(self.preferences, default_flow_style=False))
+    
+    def remember(self, key: str, value: Any, source: str = "user"):
+        """Store a preference with validation."""
+        # Validate key
+        if not key or len(key) > 100:
+            raise ValueError("Invalid key length")
+        
+        # Validate value
+        value_str = str(value)
+        if len(value_str) > self.MAX_VALUE_LENGTH:
+            raise ValueError(f"Value exceeds max length of {self.MAX_VALUE_LENGTH}")
+        
+        # Check entry limit
+        if len(self.preferences) >= self.MAX_ENTRIES and key not in self.preferences:
+            raise ValueError(f"Max entries ({self.MAX_ENTRIES}) reached")
+        
+        # Store with metadata
+        self.preferences[key] = {
+            "value": value,
+            "source": source,
+            "updated_at": datetime.now().isoformat()
+        }
+        self._save()
+    
+    def recall(self, key: str, default: Any = None) -> Any:
+        """Retrieve a preference."""
+        entry = self.preferences.get(key)
+        if entry:
+            return entry["value"]
+        return default
+    
+    def list_all(self) -> dict:
+        """Get all preferences for context injection."""
+        return {k: v["value"] for k, v in self.preferences.items()}
+    
+    def forget(self, key: str):
+        """Remove a preference."""
+        if key in self.preferences:
+            del self.preferences[key]
+            self._save()
+```
+
+## Integration Example
+
+Combining patterns in an agent harness:
+
+```python
+class FilesystemContextAgent:
+    """Agent with filesystem-based context management."""
+    
+    def __init__(self):
+        self.scratch = ScratchPadManager()
+        self.skills = SkillLoader()
+        self.preferences = PreferenceStore()
+        self.workspace = AgentWorkspace("main_agent")
+    
+    def handle_tool_output(self, tool_name: str, output: str) -> str:
+        """Process tool output, offloading if necessary."""
+        if self.scratch.should_offload(output):
+            ref = self.scratch.offload(output, source=tool_name)
+            return f"[{tool_name} output saved to {ref['path']}. Summary: {ref['summary'][:200]}]"
+        return output
+    
+    def get_system_prompt(self) -> str:
+        """Build system prompt with dynamic skill references."""
+        base_prompt = "You are a helpful assistant."
+        skill_context = self.skills.get_static_context()
+        user_prefs = self.preferences.list_all()
+        
+        pref_section = ""
+        if user_prefs:
+            pref_section = "\n\nUser preferences:\n" + "\n".join(
+                f"- {k}: {v}" for k, v in user_prefs.items()
+            )
+        
+        return f"{base_prompt}\n\n{skill_context}{pref_section}"
+```
+
+## File Organization Best Practices
+
+```
+project/
+├── scratch/                    # Ephemeral working files
+│   ├── tool_outputs/          # Large tool results
+│   │   └── search_20260107.txt
+│   └── plans/                 # Active task plans
+│       └── current_plan.yaml
+├── workspace/                  # Agent workspaces
+│   └── agents/
+│       ├── research_agent/
+│       │   ├── findings.md
+│       │   └── status.json
+│       └── code_agent/
+│           ├── findings.md
+│           └── status.json
+├── agent/                      # Agent configuration
+│   ├── preferences.yaml       # Learned preferences
+│   └── patterns.md           # Discovered patterns
+├── skills/                     # Loadable skills
+│   └── {skill-name}/
+│       └── SKILL.md
+├── terminals/                  # Terminal output
+│   ├── 1.txt
+│   └── 2.txt
+└── history/                    # Chat history archives
+    └── session_001.txt
+```
+
+## Token Accounting Metrics
+
+Track these metrics to validate filesystem patterns:
+
+1. **Static context ratio**: tokens in static context / total tokens
+2. **Dynamic load rate**: how often skills/files are loaded per task
+3. **Offload savings**: tokens saved by writing to files vs keeping in context
+4. **Retrieval precision**: percentage of loaded content actually used
+
+Target benchmarks:
+- Static context ratio < 20%
+- Offload savings > 50% for tool-heavy workflows
+- Retrieval precision > 70% (loaded content is relevant)
+

--- a/skills/filesystem-context/scripts/filesystem_context.py
+++ b/skills/filesystem-context/scripts/filesystem_context.py
@@ -1,0 +1,353 @@
+"""
+Filesystem Context Manager
+
+Demonstrates the core patterns for filesystem-based context engineering:
+1. Scratch pad for tool output offloading
+2. Plan persistence for long-horizon tasks
+3. Dynamic context discovery with file references
+
+Usage:
+    python filesystem_context.py
+
+This script demonstrates concepts without external dependencies.
+"""
+
+import os
+import json
+from datetime import datetime
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any
+
+
+# =============================================================================
+# Pattern 1: Scratch Pad Manager
+# =============================================================================
+
+class ScratchPadManager:
+    """
+    Manages temporary file storage for offloading large tool outputs.
+    
+    Instead of keeping 10k tokens of search results in context,
+    write them to a file and return a reference. The agent can
+    then grep or read specific sections as needed.
+    """
+    
+    def __init__(self, base_path: str = "scratch", token_threshold: int = 2000):
+        self.base_path = Path(base_path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.token_threshold = token_threshold
+    
+    def estimate_tokens(self, content: str) -> int:
+        """Rough token estimate: ~4 characters per token."""
+        return len(content) // 4
+    
+    def should_offload(self, content: str) -> bool:
+        """Determine if content exceeds threshold for offloading."""
+        return self.estimate_tokens(content) > self.token_threshold
+    
+    def offload(self, content: str, source: str) -> Dict[str, Any]:
+        """
+        Write content to file, return compact reference.
+        
+        The reference includes:
+        - File path for later retrieval
+        - Summary of first few lines
+        - Token estimate for the full content
+        """
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        filename = f"{source}_{timestamp}.txt"
+        file_path = self.base_path / filename
+        
+        file_path.write_text(content)
+        
+        # Extract summary from first meaningful lines
+        lines = content.strip().split('\n')[:5]
+        summary = '\n'.join(lines)
+        if len(summary) > 300:
+            summary = summary[:300] + "..."
+        
+        return {
+            "path": str(file_path),
+            "source": source,
+            "tokens_saved": self.estimate_tokens(content),
+            "summary": summary
+        }
+    
+    def format_reference(self, ref: Dict[str, Any]) -> str:
+        """Format reference for inclusion in context."""
+        return (
+            f"[Output from {ref['source']} saved to {ref['path']}. "
+            f"~{ref['tokens_saved']} tokens. "
+            f"Summary: {ref['summary'][:200]}]"
+        )
+
+
+# =============================================================================
+# Pattern 2: Plan Persistence
+# =============================================================================
+
+@dataclass
+class PlanStep:
+    """Individual step in an agent plan."""
+    id: int
+    description: str
+    status: str = "pending"  # pending, in_progress, completed, blocked
+    notes: Optional[str] = None
+
+
+@dataclass
+class AgentPlan:
+    """
+    Persistent plan that survives context window limitations.
+    
+    Write the plan to disk so the agent can re-read it at any point,
+    even after summarization or context window refresh.
+    """
+    objective: str
+    steps: List[PlanStep] = field(default_factory=list)
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    
+    def to_dict(self) -> dict:
+        return {
+            "objective": self.objective,
+            "created_at": self.created_at,
+            "steps": [
+                {
+                    "id": s.id,
+                    "description": s.description,
+                    "status": s.status,
+                    "notes": s.notes
+                }
+                for s in self.steps
+            ]
+        }
+    
+    def save(self, path: str = "scratch/current_plan.json"):
+        """Persist plan to filesystem."""
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, 'w') as f:
+            json.dump(self.to_dict(), f, indent=2)
+        print(f"Plan saved to {path}")
+    
+    @classmethod
+    def load(cls, path: str = "scratch/current_plan.json") -> "AgentPlan":
+        """Load plan from filesystem."""
+        with open(path, 'r') as f:
+            data = json.load(f)
+        
+        plan = cls(objective=data["objective"])
+        plan.created_at = data.get("created_at", "")
+        
+        for step_data in data.get("steps", []):
+            plan.steps.append(PlanStep(
+                id=step_data["id"],
+                description=step_data["description"],
+                status=step_data["status"],
+                notes=step_data.get("notes")
+            ))
+        return plan
+    
+    def current_step(self) -> Optional[PlanStep]:
+        """Get the current (first non-completed) step."""
+        for step in self.steps:
+            if step.status not in ["completed", "cancelled"]:
+                return step
+        return None
+    
+    def complete_step(self, step_id: int, notes: str = None):
+        """Mark a step as completed."""
+        for step in self.steps:
+            if step.id == step_id:
+                step.status = "completed"
+                if notes:
+                    step.notes = notes
+                return
+        raise ValueError(f"Step {step_id} not found")
+    
+    def progress_summary(self) -> str:
+        """Generate summary for context injection."""
+        completed = sum(1 for s in self.steps if s.status == "completed")
+        total = len(self.steps)
+        current = self.current_step()
+        
+        summary = f"Objective: {self.objective}\n"
+        summary += f"Progress: {completed}/{total} steps completed\n"
+        if current:
+            summary += f"Current step: [{current.id}] {current.description}"
+        else:
+            summary += "All steps completed."
+        
+        return summary
+
+
+# =============================================================================
+# Pattern 3: Tool Output Handler
+# =============================================================================
+
+class ToolOutputHandler:
+    """
+    Handles tool outputs with automatic offloading decision.
+    
+    Small outputs stay in context. Large outputs get written to files
+    with a compact reference returned instead.
+    """
+    
+    def __init__(self, scratch_pad: ScratchPadManager = None):
+        self.scratch_pad = scratch_pad or ScratchPadManager()
+    
+    def process_output(self, tool_name: str, output: str) -> str:
+        """
+        Process tool output, offloading if too large.
+        
+        Returns either:
+        - The original output (if small enough)
+        - A file reference with summary (if too large)
+        """
+        if self.scratch_pad.should_offload(output):
+            ref = self.scratch_pad.offload(output, source=tool_name)
+            return self.scratch_pad.format_reference(ref)
+        return output
+
+
+# =============================================================================
+# Demonstration
+# =============================================================================
+
+def demo_scratch_pad():
+    """Demonstrate scratch pad pattern."""
+    print("=" * 60)
+    print("DEMO: Scratch Pad for Tool Output Offloading")
+    print("=" * 60)
+    
+    scratch = ScratchPadManager(base_path="demo_scratch", token_threshold=100)
+    
+    # Small output stays in context
+    small_output = "API returned: {'status': 'ok', 'data': [1, 2, 3]}"
+    print(f"\nSmall output ({scratch.estimate_tokens(small_output)} tokens):")
+    print(f"  Should offload: {scratch.should_offload(small_output)}")
+    
+    # Large output gets offloaded
+    large_output = """
+Search Results for "context engineering":
+
+1. Context Engineering: The Art of Curating LLM Context
+   URL: https://example.com/article1
+   Snippet: Context engineering is the discipline of managing what information 
+   enters the language model's context window. Unlike prompt engineering which
+   focuses on instruction crafting, context engineering addresses the holistic
+   curation of all information...
+   
+2. Building Production Agents with Effective Context Management
+   URL: https://example.com/article2
+   Snippet: Production agent systems require sophisticated context management
+   strategies. This includes compression, caching, and strategic partitioning
+   of work across sub-agents with isolated contexts...
+   
+3. The Lost-in-Middle Problem and How to Avoid It
+   URL: https://example.com/article3
+   Snippet: Research shows that language models exhibit U-shaped attention
+   patterns, with information in the middle of long contexts receiving less
+   attention than content at the beginning or end...
+
+... (imagine 50 more results) ...
+"""
+    
+    print(f"\nLarge output ({scratch.estimate_tokens(large_output)} tokens):")
+    print(f"  Should offload: {scratch.should_offload(large_output)}")
+    
+    if scratch.should_offload(large_output):
+        ref = scratch.offload(large_output, source="web_search")
+        print(f"\nOffloaded to: {ref['path']}")
+        print(f"Tokens saved: {ref['tokens_saved']}")
+        print(f"\nReference for context:\n{scratch.format_reference(ref)}")
+
+
+def demo_plan_persistence():
+    """Demonstrate plan persistence pattern."""
+    print("\n" + "=" * 60)
+    print("DEMO: Plan Persistence for Long-Horizon Tasks")
+    print("=" * 60)
+    
+    # Create a plan
+    plan = AgentPlan(objective="Refactor authentication module")
+    plan.steps = [
+        PlanStep(id=1, description="Audit current auth endpoints"),
+        PlanStep(id=2, description="Design new token validation flow"),
+        PlanStep(id=3, description="Implement changes"),
+        PlanStep(id=4, description="Write tests"),
+        PlanStep(id=5, description="Deploy and monitor"),
+    ]
+    
+    print("\nInitial plan:")
+    print(plan.progress_summary())
+    
+    # Save to filesystem
+    plan.save("demo_scratch/current_plan.json")
+    
+    # Simulate completing first step
+    plan.complete_step(1, notes="Found 12 endpoints, 3 need updates")
+    plan.steps[1].status = "in_progress"
+    
+    print("\nAfter completing step 1:")
+    print(plan.progress_summary())
+    
+    # Save updated plan
+    plan.save("demo_scratch/current_plan.json")
+    
+    # Simulate loading from file (as if in new context)
+    print("\n--- Simulating context refresh ---")
+    loaded_plan = AgentPlan.load("demo_scratch/current_plan.json")
+    print("\nPlan loaded from file:")
+    print(loaded_plan.progress_summary())
+
+
+def demo_tool_handler():
+    """Demonstrate integrated tool output handling."""
+    print("\n" + "=" * 60)
+    print("DEMO: Integrated Tool Output Handler")
+    print("=" * 60)
+    
+    handler = ToolOutputHandler(
+        scratch_pad=ScratchPadManager(base_path="demo_scratch", token_threshold=50)
+    )
+    
+    outputs = [
+        ("calculator", "42"),
+        ("file_read", "Error: File not found"),
+        ("database_query", """
+            Results (250 rows):
+            | id | name | email | created_at | status |
+            |----|------|-------|------------|--------|
+            | 1  | John | j@e.c | 2024-01-01 | active |
+            | 2  | Jane | j@e.c | 2024-01-02 | active |
+            ... (248 more rows) ...
+        """),
+    ]
+    
+    for tool_name, output in outputs:
+        processed = handler.process_output(tool_name, output)
+        print(f"\n{tool_name}:")
+        print(f"  Original length: {len(output)} chars")
+        print(f"  Processed: {processed[:100]}...")
+
+
+def cleanup_demo():
+    """Clean up demo files."""
+    import shutil
+    demo_path = Path("demo_scratch")
+    if demo_path.exists():
+        shutil.rmtree(demo_path)
+        print("\nDemo files cleaned up.")
+
+
+if __name__ == "__main__":
+    demo_scratch_pad()
+    demo_plan_persistence()
+    demo_tool_handler()
+    
+    print("\n" + "=" * 60)
+    print("Cleanup demo files? (y/n): ", end="")
+    # Auto-cleanup for non-interactive runs
+    cleanup_demo()
+


### PR DESCRIPTION
New skill covering filesystem-based context engineering patterns:
- Scratch pad pattern for tool output offloading
- Plan persistence for long-horizon tasks
- Sub-agent file-based communication
- Dynamic skill loading
- Terminal/log persistence
- Self-modification patterns

Includes SKILL.md, implementation patterns reference, and demo script. Added to agent-architecture plugin in marketplace.