### PR TITLE
docs: add AdaL to compatible platforms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Each skill is structured for efficient context use. At startup, agents load only
 
 ### Platform Agnosticism
 
-These skills focus on transferable principles rather than vendor-specific implementations. The patterns work across Claude Code, Cursor, and any agent platform that supports skills or allows custom instructions.
+These skills focus on transferable principles rather than vendor-specific implementations. The patterns work across Claude Code, Cursor, AdaL, and any agent platform that supports skills or allows custom instructions.
 
 ### Conceptual Foundation with Practical Examples
 


### PR DESCRIPTION
## Summary

Adds AdaL to the Platform Agnosticism section as a compatible agent platform.

## About AdaL

[AdaL](https://sylph.ai) is a self-evolving AI coding agent that is fully compatible with Claude Code skills and the Agent Skills format. It supports context engineering principles and can leverage these skills effectively.

## Changes

- Added AdaL to the platform list: "Claude Code, Cursor, AdaL, and any agent platform..."

---

🌸 Generated with [AdaL](https://github.com/SylphAI-Inc/adal-cli)