### PR TITLE
Add Cognee as a memory framework in memory-systems skill

### DIFF
--- a/skills/memory-systems/references/implementation.md
+++ b/skills/memory-systems/references/implementation.md
@@ -524,3 +524,28 @@ await graphiti.add_episode(
 results = await graphiti.search("Where does Alice live?")
 ```
 
+### Cognee (Open-Source Knowledge Engine for AI Memory)
+
+```python
+import cognee
+from cognee.modules.search.types import SearchType
+
+# ECL pipeline: add → cognify → memify → search
+await cognee.add("./docs/")
+await cognee.add("any-data")
+await cognee.cognify()
+await cognee.memify()
+
+# Graph-aware retrieval (default: GRAPH_COMPLETION)
+results = await cognee.search(
+    query_text="any query to search in memory",
+    query_type=SearchType.GRAPH_COMPLETION,
+)
+
+# Raw chunks when agent reasons over text itself
+chunks = await cognee.search(
+    query_text="any query to search in memory",
+    query_type=SearchType.CHUNKS,
+)
+```
+


### PR DESCRIPTION
Adds Cognee as a production memory framework throughout the memory-systems skill

- Added Cognee to framework landscape table with architecture, best-for, and trade-off descriptions
- Added Cognee paragraph in framework commentary
- Added HotPotQA column to benchmark table with results for Cognee, Zep, and Mem0
- Added Cognee to retrieval strategies discussion 
- Added Cognee to "Choosing a Memory Architecture" progression 
- Added Cognee code example (Example 3)
- Added Cognee references (GitHub, arXiv paper, blog post)
- Updated skill triggers, version (3.0.0), and last-updated date
- skills/memory-systems/references/implementation.md
- Added Cognee quick-start section matching the concise style of the existing Mem0 and Graphiti sections