### PR TITLE
fix interleaved-thinking install path

### DIFF
--- a/examples/interleaved-thinking/README.md
+++ b/examples/interleaved-thinking/README.md
@@ -93,7 +93,7 @@ Each detected pattern includes:
 ### Installation
 
 ```bash
-cd examples/interleaved_thinking
+cd examples/interleaved-thinking
 pip install -e .
 ```
 

--- a/examples/interleaved-thinking/pyproject.toml
+++ b/examples/interleaved-thinking/pyproject.toml
@@ -51,7 +51,7 @@ rto = "reasoning_trace_optimizer.cli:main"
 [project.urls]
 Homepage = "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering"
 Repository = "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering"
-Documentation = "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/examples/interleaved_thinking"
+Documentation = "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/examples/interleaved-thinking"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
## Summary
- update the Quick Start install command in the interleaved-thinking example to use the actual directory name
- closes #42

## Testing
- verified the repository uses `examples/interleaved-thinking/` locally and on `origin/main`