### PR TITLE
Improve multi-agent-patterns skill and add skill review workflow

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,14 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@3505a029f9a978284a74edacfbf7045625627db3 # main

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -11,4 +11,4 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: tesslio/skill-review@3505a029f9a978284a74edacfbf7045625627db3 # main
+      - uses: tesslio/skill-review@14b47c8420ff9ac9a12c30ed4b89ce0e9d0355ae # main

--- a/skills/multi-agent-patterns/SKILL.md
+++ b/skills/multi-agent-patterns/SKILL.md
@@ -1,255 +1,133 @@
 ---
 name: multi-agent-patterns
-description: This skill should be used when the user asks to "design multi-agent system", "implement supervisor pattern", "create swarm architecture", "coordinate multiple agents", or mentions multi-agent patterns, context isolation, agent handoffs, sub-agents, or parallel agent execution.
+description: Designs and implements multi-agent architectures including supervisor/orchestrator, swarm, and hierarchical patterns with context isolation, coordination protocols, and failure recovery. Use when asked to design multi-agent systems, implement supervisor patterns, create swarm architectures, coordinate multiple agents, set up agent handoffs, or build parallel agent execution pipelines.
 ---
 
 # Multi-Agent Architecture Patterns
 
-Multi-agent architectures distribute work across multiple language model instances, each with its own context window. When designed well, this distribution enables capabilities beyond single-agent limits. When designed poorly, it introduces coordination overhead that negates benefits. The critical insight is that sub-agents exist primarily to isolate context, not to anthropomorphize role division.
+Sub-agents exist primarily to isolate context, not to anthropomorphize role division. Design decisions should follow from this principle.
 
-## When to Activate
+## When to Use Multi-Agent vs Single-Agent
 
-Activate this skill when:
-- Single-agent context limits constrain task complexity
-- Tasks decompose naturally into parallel subtasks
-- Different subtasks require different tool sets or system prompts
-- Building systems that must handle multiple domains simultaneously
-- Scaling agent capabilities beyond single-context limits
-- Designing production agent systems with multiple specialized components
+| Signal | Use Multi-Agent | Stay Single-Agent |
+|--------|----------------|-------------------|
+| Context filling up with mixed concerns | Yes | - |
+| Parallelizable independent subtasks | Yes | - |
+| Different subtasks need different tools/prompts | Yes | - |
+| Simple sequential task | - | Yes |
+| Coordination overhead > parallelization gain | - | Yes |
+| Task fits comfortably in one context | - | Yes |
 
-## Core Concepts
+**Cost reality**: Multi-agent systems use ~15x tokens vs single-agent. Model upgrades often outperform token budget increases. Choose multi-agent only when the task structure demands it.
 
-Multi-agent systems address single-agent context limitations through distribution. Three dominant patterns exist: supervisor/orchestrator for centralized control, peer-to-peer/swarm for flexible handoffs, and hierarchical for layered abstraction. The critical design principle is context isolation—sub-agents exist primarily to partition context rather than to simulate organizational roles.
+## Architectural Patterns
 
-Effective multi-agent systems require explicit coordination protocols, consensus mechanisms that avoid sycophancy, and careful attention to failure modes including bottlenecks, divergence, and error propagation.
+### Pattern 1: Supervisor/Orchestrator
 
-## Detailed Topics
-
-### Why Multi-Agent Architectures
-
-**The Context Bottleneck**
-Single agents face inherent ceilings in reasoning capability, context management, and tool coordination. As tasks grow more complex, context windows fill with accumulated history, retrieved documents, and tool outputs. Performance degrades according to predictable patterns: the lost-in-middle effect, attention scarcity, and context poisoning.
-
-Multi-agent architectures address these limitations by partitioning work across multiple context windows. Each agent operates in a clean context focused on its subtask. Results aggregate at a coordination layer without any single context bearing the full burden.
-
-**The Token Economics Reality**
-Multi-agent systems consume significantly more tokens than single-agent approaches. Production data shows:
-
-| Architecture | Token Multiplier | Use Case |
-|--------------|------------------|----------|
-| Single agent chat | 1× baseline | Simple queries |
-| Single agent with tools | ~4× baseline | Tool-using tasks |
-| Multi-agent system | ~15× baseline | Complex research/coordination |
-
-Research on the BrowseComp evaluation found that three factors explain 95% of performance variance: token usage (80% of variance), number of tool calls, and model choice. This validates the multi-agent approach of distributing work across agents with separate context windows to add capacity for parallel reasoning.
-
-Critically, upgrading to better models often provides larger performance gains than doubling token budgets. Claude Sonnet 4.5 showed larger gains than doubling tokens on earlier Sonnet versions. GPT-5.2's thinking mode similarly outperforms raw token increases. This suggests model selection and multi-agent architecture are complementary strategies.
-
-**The Parallelization Argument**
-Many tasks contain parallelizable subtasks that a single agent must execute sequentially. A research task might require searching multiple independent sources, analyzing different documents, or comparing competing approaches. A single agent processes these sequentially, accumulating context with each step.
-
-Multi-agent architectures assign each subtask to a dedicated agent with a fresh context. All agents work simultaneously, then return results to a coordinator. The total real-world time approaches the duration of the longest subtask rather than the sum of all subtasks.
-
-**The Specialization Argument**
-Different tasks benefit from different agent configurations: different system prompts, different tool sets, different context structures. A general-purpose agent must carry all possible configurations in context. Specialized agents carry only what they need.
-
-Multi-agent architectures enable specialization without combinatorial explosion. The coordinator routes to specialized agents; each agent operates with lean context optimized for its domain.
-
-### Architectural Patterns
-
-**Pattern 1: Supervisor/Orchestrator**
-The supervisor pattern places a central agent in control, delegating to specialists and synthesizing results. The supervisor maintains global state and trajectory, decomposes user objectives into subtasks, and routes to appropriate workers.
+Central agent delegates to specialists and synthesizes results.
 
 ```
 User Query -> Supervisor -> [Specialist, Specialist, Specialist] -> Aggregation -> Final Output
 ```
 
-When to use: Complex tasks with clear decomposition, tasks requiring coordination across domains, tasks where human oversight is important.
+**Use when**: Clear task decomposition, cross-domain coordination, human oversight needed.
 
-Advantages: Strict control over workflow, easier to implement human-in-the-loop interventions, ensures adherence to predefined plans.
-
-Disadvantages: Supervisor context becomes bottleneck, supervisor failures cascade to all workers, "telephone game" problem where supervisors paraphrase sub-agent responses incorrectly.
-
-**The Telephone Game Problem and Solution**
-LangGraph benchmarks found supervisor architectures initially performed 50% worse than optimized versions due to the "telephone game" problem where supervisors paraphrase sub-agent responses incorrectly, losing fidelity.
-
-The fix: implement a `forward_message` tool allowing sub-agents to pass responses directly to users:
+**Key risk - Telephone Game**: Supervisors paraphrase sub-agent responses, losing fidelity (50% perf drop in LangGraph benchmarks). Fix with a `forward_message` tool:
 
 ```python
 def forward_message(message: str, to_user: bool = True):
-    """
-    Forward sub-agent response directly to user without supervisor synthesis.
-    
-    Use when:
-    - Sub-agent response is final and complete
-    - Supervisor synthesis would lose important details
-    - Response format must be preserved exactly
-    """
+    """Forward sub-agent response directly, bypassing supervisor synthesis."""
     if to_user:
         return {"type": "direct_response", "content": message}
     return {"type": "supervisor_input", "content": message}
 ```
 
-With this pattern, swarm architectures slightly outperform supervisors because sub-agents respond directly to users, eliminating translation errors.
+### Pattern 2: Peer-to-Peer/Swarm
 
-Implementation note: Implement direct pass-through mechanisms allowing sub-agents to pass responses directly to users rather than through supervisor synthesis when appropriate.
-
-**Pattern 2: Peer-to-Peer/Swarm**
-The peer-to-peer pattern removes central control, allowing agents to communicate directly based on predefined protocols. Any agent can transfer control to any other through explicit handoff mechanisms.
+No central control. Agents hand off to each other via explicit transfer functions.
 
 ```python
 def transfer_to_agent_b():
     return agent_b  # Handoff via function return
 
-agent_a = Agent(
-    name="Agent A",
-    functions=[transfer_to_agent_b]
-)
+agent_a = Agent(name="Agent A", functions=[transfer_to_agent_b])
 ```
 
-When to use: Tasks requiring flexible exploration, tasks where rigid planning is counterproductive, tasks with emergent requirements that defy upfront decomposition.
+**Use when**: Flexible exploration, emergent requirements, rigid planning is counterproductive.
 
-Advantages: No single point of failure, scales effectively for breadth-first exploration, enables emergent problem-solving behaviors.
+**Key risk**: Divergence without central state. Mitigate with convergence constraints and time-to-live limits.
 
-Disadvantages: Coordination complexity increases with agent count, risk of divergence without central state keeper, requires robust convergence constraints.
+### Pattern 3: Hierarchical
 
-Implementation note: Define explicit handoff protocols with state passing. Ensure agents can communicate their context needs to receiving agents.
+Layered abstraction: strategy (goals) -> planning (decomposition) -> execution (atomic tasks).
 
-**Pattern 3: Hierarchical**
-Hierarchical structures organize agents into layers of abstraction: strategic, planning, and execution layers. Strategy layer agents define goals and constraints; planning layer agents break goals into actionable plans; execution layer agents perform atomic tasks.
+**Use when**: Large-scale projects, enterprise workflows, mixed high-level/detailed execution.
 
-```
-Strategy Layer (Goal Definition) -> Planning Layer (Task Decomposition) -> Execution Layer (Atomic Tasks)
-```
+## Context Isolation
 
-When to use: Large-scale projects with clear hierarchical structure, enterprise workflows with management layers, tasks requiring both high-level planning and detailed execution.
+The primary benefit of multi-agent systems. Choose isolation strategy per subtask:
 
-Advantages: Mirrors organizational structures, clear separation of concerns, enables different context structures at different levels.
+| Strategy | When to Use | Trade-off |
+|----------|-------------|-----------|
+| Full context delegation | Complex tasks needing complete understanding | Defeats isolation purpose if overused |
+| Instruction passing | Simple, well-defined subtasks | Limits sub-agent flexibility |
+| File system coordination | Shared state across agents | Latency + consistency challenges |
 
-Disadvantages: Coordination overhead between layers, potential for misalignment between strategy and execution, complex error propagation.
+## Consensus and Coordination
 
-### Context Isolation as Design Principle
+Simple majority voting fails because it weights hallucinations equally with reasoning. Use instead:
 
-The primary purpose of multi-agent architectures is context isolation. Each sub-agent operates in a clean context window focused on its subtask without carrying accumulated context from other subtasks.
+1. **Weighted voting**: Weight by `confidence * domain_expertise`
+2. **Debate protocols**: Adversarial critique over multiple rounds (higher accuracy than collaborative consensus)
+3. **Trigger-based intervention**: Monitor for stalls (no progress) and sycophancy (agents mimicking without unique reasoning)
 
-**Isolation Mechanisms**
-Full context delegation: For complex tasks where the sub-agent needs complete understanding, the planner shares its entire context. The sub-agent has its own tools and instructions but receives full context for its decisions.
+## Implementation Workflow
 
-Instruction passing: For simple, well-defined subtasks, the planner creates instructions via function call. The sub-agent receives only the instructions needed for its specific task.
+Follow these steps when building a multi-agent system:
 
-File system memory: For complex tasks requiring shared state, agents read and write to persistent storage. The file system serves as the coordination mechanism, avoiding context bloat from shared state passing.
+### Step 1: Validate the Need
+- Confirm single-agent cannot handle the task (context overflow, parallelization needed, or tool specialization required)
+- If the task fits in one context window, stop here
 
-**Isolation Trade-offs**
-Full context delegation provides maximum capability but defeats the purpose of sub-agents. Instruction passing maintains isolation but limits sub-agent flexibility. File system memory enables shared state without context passing but introduces latency and consistency challenges.
+### Step 2: Choose Pattern
+- **Supervisor** if you need centralized control and human oversight
+- **Swarm** if tasks are exploratory with emergent requirements
+- **Hierarchical** if the project has natural abstraction layers
 
-The right choice depends on task complexity, coordination needs, and acceptable latency.
+### Step 3: Define Agent Boundaries
+For each agent, specify:
+- System prompt (focused, no unnecessary context)
+- Tool set (only what this agent needs)
+- Output schema (structured, validated before passing downstream)
+- Time-to-live limit (prevent infinite loops)
 
-### Consensus and Coordination
-
-**The Voting Problem**
-Simple majority voting treats hallucinations from weak models as equal to reasoning from strong models. Without intervention, multi-agent discussions devolve into consensus on false premises due to inherent bias toward agreement.
-
-**Weighted Voting**
-Weight agent votes by confidence or expertise. Agents with higher confidence or domain expertise carry more weight in final decisions.
-
-**Debate Protocols**
-Debate protocols require agents to critique each other's outputs over multiple rounds. Adversarial critique often yields higher accuracy on complex reasoning than collaborative consensus.
-
-**Trigger-Based Intervention**
-Monitor multi-agent interactions for specific behavioral markers. Stall triggers activate when discussions make no progress. Sycophancy triggers detect when agents mimic each other's answers without unique reasoning.
-
-### Framework Considerations
-
-Different frameworks implement these patterns with different philosophies. LangGraph uses graph-based state machines with explicit nodes and edges. AutoGen uses conversational/event-driven patterns with GroupChat. CrewAI uses role-based process flows with hierarchical crew structures.
-
-## Practical Guidance
-
-### Failure Modes and Mitigations
-
-**Failure: Supervisor Bottleneck**
-The supervisor accumulates context from all workers, becoming susceptible to saturation and degradation.
-
-Mitigation: Implement output schema constraints so workers return only distilled summaries. Use checkpointing to persist supervisor state without carrying full history.
-
-**Failure: Coordination Overhead**
-Agent communication consumes tokens and introduces latency. Complex coordination can negate parallelization benefits.
-
-Mitigation: Minimize communication through clear handoff protocols. Batch results where possible. Use asynchronous communication patterns.
-
-**Failure: Divergence**
-Agents pursuing different goals without central coordination can drift from intended objectives.
-
-Mitigation: Define clear objective boundaries for each agent. Implement convergence checks that verify progress toward shared goals. Use time-to-live limits on agent execution.
-
-**Failure: Error Propagation**
-Errors in one agent's output propagate to downstream agents that consume that output.
-
-Mitigation: Validate agent outputs before passing to consumers. Implement retry logic with circuit breakers. Use idempotent operations where possible.
-
-## Examples
-
-**Example 1: Research Team Architecture**
-```text
-Supervisor
-├── Researcher (web search, document retrieval)
-├── Analyzer (data analysis, statistics)
-├── Fact-checker (verification, validation)
-└── Writer (report generation, formatting)
-```
-
-**Example 2: Handoff Protocol**
+### Step 4: Implement Coordination
 ```python
-def handle_customer_request(request):
+# Handoff with explicit state transfer
+def handle_request(request):
     if request.type == "billing":
-        return transfer_to(billing_agent)
+        return transfer_to(billing_agent, context=request.billing_context)
     elif request.type == "technical":
-        return transfer_to(technical_agent)
-    elif request.type == "sales":
-        return transfer_to(sales_agent)
+        return transfer_to(technical_agent, context=request.tech_context)
     else:
         return handle_general(request)
 ```
 
-## Guidelines
+### Step 5: Add Failure Recovery
+For each agent-to-agent boundary:
+- Validate outputs before passing downstream (prevent error propagation)
+- Implement circuit breakers: 3 failures -> reroute to backup agent
+- Use exponential backoff on retries: `delay = min(2^attempt, 60)`
+- Checkpoint supervisor state to avoid context accumulation
 
-1. Design for context isolation as the primary benefit of multi-agent systems
-2. Choose architecture pattern based on coordination needs, not organizational metaphor
-3. Implement explicit handoff protocols with state passing
-4. Use weighted voting or debate protocols for consensus
-5. Monitor for supervisor bottlenecks and implement checkpointing
-6. Validate outputs before passing between agents
-7. Set time-to-live limits to prevent infinite loops
-8. Test failure scenarios explicitly
-
-## Integration
-
-This skill builds on context-fundamentals and context-degradation. It connects to:
-
-- memory-systems - Shared state management across agents
-- tool-design - Tool specialization per agent
-- context-optimization - Context partitioning strategies
+### Step 6: Verify
+- [ ] Each agent's context stays focused (no cross-contamination)
+- [ ] Supervisor uses `forward_message` where synthesis would lose fidelity
+- [ ] Circuit breakers configured for all agents
+- [ ] Time-to-live limits prevent runaway execution
+- [ ] Output schemas validated at every handoff point
 
 ## References
 
-Internal reference:
-- [Frameworks Reference](./references/frameworks.md) - Detailed framework implementation patterns
-
-Related skills in this collection:
-- context-fundamentals - Context basics
-- memory-systems - Cross-agent memory
-- context-optimization - Partitioning strategies
-
-External resources:
-- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/) - Multi-agent patterns and state management
-- [AutoGen Framework](https://microsoft.github.io/autogen/) - GroupChat and conversational patterns
-- [CrewAI Documentation](https://docs.crewai.com/) - Hierarchical agent processes
-- [Research on Multi-Agent Coordination](https://arxiv.org/abs/2308.00352) - Survey of multi-agent systems
-
----
-
-## Skill Metadata
-
-**Created**: 2025-12-20
-**Last Updated**: 2025-12-20
-**Author**: Agent Skills for Context Engineering Contributors
-**Version**: 1.0.0
+- [Frameworks Reference](./references/frameworks.md) - LangGraph, AutoGen, CrewAI implementation patterns
+- Related skills: context-fundamentals, memory-systems, context-optimization, tool-design


### PR DESCRIPTION
Hey @muratcankoylan, glad [#39](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/pull/39) was useful - reviewed this skill as well, and made some improvements.

ran the multi-agent-patterns skill through evals, found quick fixes (description went from `37%` to `100%`, content went from `57%` to `100%`):

- architectural patterns were verbose with repeated explanations - trimmed each to core guidance, key risk, and code example

- no implementation workflow existed - added a `6`-step build sequence with validation checkpoints and a verification checklist

- failure modes were described abstractly and replaced with concrete thresholds (circuit breaker after `3` failures, exponential backoff formula, TTL limits)

also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR. with `10+` skills and contributions coming in, it gives you (and contributors) an instant quality signal before you have to review yourself (no signup, no tokens needed).

happy to keep contributing fixes like this if it’s helpful.