### PR TITLE
fix: score structured ground truth in compression evaluator

### DIFF
--- a/skills/context-compression/scripts/compression_evaluator.py
+++ b/skills/context-compression/scripts/compression_evaluator.py
@@ -397,10 +397,52 @@ class CompressionEvaluator:
         if any(ext in response for ext in [".ts", ".py", ".js", ".md"]):
             score += 0.5  # Contains file references
         
-        if ground_truth and ground_truth in response:
-            score += 1.0  # Contains ground truth
+        overlap_ratio = self._ground_truth_overlap_ratio(response, ground_truth)
+        if overlap_ratio >= 0.75:
+            score += 1.0
+        elif overlap_ratio >= 0.4:
+            score += 0.5
+        elif ground_truth:
+            score -= 0.5
         
         return min(5.0, max(0.0, score))
+
+    def _ground_truth_overlap_ratio(self,
+                                    response: str,
+                                    ground_truth: Optional[str]) -> float:
+        if not ground_truth:
+            return 0.0
+
+        terms = self._extract_ground_truth_terms(ground_truth)
+        if not terms:
+            return 1.0 if ground_truth.lower() in response.lower() else 0.0
+
+        response_lower = response.lower()
+        matches = sum(1 for term in terms if term in response_lower)
+        return matches / len(terms)
+
+    def _extract_ground_truth_terms(self, ground_truth: str) -> List[str]:
+        try:
+            parsed = json.loads(ground_truth)
+        except json.JSONDecodeError:
+            return [ground_truth.lower()] if ground_truth.strip() else []
+
+        terms: List[str] = []
+
+        def collect(value) -> None:
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized:
+                    terms.append(normalized)
+            elif isinstance(value, dict):
+                for nested in value.values():
+                    collect(nested)
+            elif isinstance(value, list):
+                for nested in value:
+                    collect(nested)
+
+        collect(parsed)
+        return list(dict.fromkeys(terms))
     
     def _calculate_dimension_scores(self, 
                                     criterion_results: List[CriterionResult]) -> Dict[str, float]:

--- a/skills/context-compression/tests/test_compression_evaluator.py
+++ b/skills/context-compression/tests/test_compression_evaluator.py
@@ -1,0 +1,56 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "compression_evaluator.py"
+)
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "compression_evaluator", MODULE_PATH
+)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load compression_evaluator.py from {MODULE_PATH}")
+COMPRESSION_EVALUATOR = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(COMPRESSION_EVALUATOR)
+
+
+class CompressionEvaluatorTests(unittest.TestCase):
+    def test_json_ground_truth_terms_score_when_response_mentions_artifacts(
+        self,
+    ) -> None:
+        evaluator = COMPRESSION_EVALUATOR.CompressionEvaluator()
+
+        rich_score = evaluator._heuristic_score(
+            {"id": "artifact_files_modified"},
+            "We modified src/app.py and updated README.md during the session.",
+            '[{"path": "src/app.py", "operation": "modified"}, {"path": "README.md", "operation": "updated"}]',
+        )
+        poor_score = evaluator._heuristic_score(
+            {"id": "artifact_files_modified"},
+            "We changed some files but I do not remember which ones.",
+            '[{"path": "src/app.py", "operation": "modified"}, {"path": "README.md", "operation": "updated"}]',
+        )
+
+        self.assertGreater(rich_score, poor_score)
+        self.assertGreaterEqual(rich_score, 4.0)
+
+    def test_plain_text_ground_truth_still_uses_substring_match(self) -> None:
+        evaluator = COMPRESSION_EVALUATOR.CompressionEvaluator()
+
+        exact_score = evaluator._heuristic_score(
+            {"id": "continuity_work_state"},
+            "Next: fix the websocket timeout before rerunning tests.",
+            "fix the websocket timeout",
+        )
+        missing_score = evaluator._heuristic_score(
+            {"id": "continuity_work_state"},
+            "Next: inspect logs again.",
+            "fix the websocket timeout",
+        )
+
+        self.assertGreater(exact_score, missing_score)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- treat JSON-encoded artifact/decision ground truth as structured terms instead of requiring an exact substring match in the model response
- reward partial overlap and penalize complete misses so the heuristic evaluator is closer to the rubric described in the evaluation framework
- add focused regression tests for JSON artifact overlap and plain-text continuation overlap

## Validation

- `python3 -m py_compile skills/context-compression/scripts/compression_evaluator.py skills/context-compression/tests/test_compression_evaluator.py`
- `python3 -m unittest discover -s skills/context-compression/tests -p "test_compression_evaluator.py"`

## Notes

- this PR is independent from `#56`, which only touched `skills/hosted-agents/`