### PR TITLE
fix: use rubric weights from dataclass dimensions

### DIFF
--- a/skills/evaluation/scripts/evaluator.py
+++ b/skills/evaluation/scripts/evaluator.py
@@ -129,7 +129,7 @@ class AgentEvaluator:
         
         # Calculate weighted overall
         overall = sum(
-            s["score"] * self.rubric[k]["weight"]
+            s["score"] * self.rubric[k].weight
             for k, s in scores.items()
         )
         

--- a/skills/evaluation/tests/test_evaluator.py
+++ b/skills/evaluation/tests/test_evaluator.py
@@ -1,0 +1,50 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "evaluator.py"
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "evaluation_evaluator", MODULE_PATH
+)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load evaluator.py from {MODULE_PATH}")
+EVALUATOR = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(EVALUATOR)
+
+
+class AgentEvaluatorTests(unittest.TestCase):
+    def test_weighted_overall_uses_rubric_dimension_weight(self) -> None:
+        rubric = {
+            "accuracy": EVALUATOR.RubricDimension(
+                name="accuracy",
+                weight=0.75,
+                description="Accuracy",
+                levels={},
+            ),
+            "completeness": EVALUATOR.RubricDimension(
+                name="completeness",
+                weight=0.25,
+                description="Completeness",
+                levels={},
+            ),
+        }
+        evaluator = EVALUATOR.AgentEvaluator(rubric=rubric)
+
+        def fake_dimension_score(
+            dimension, task, output, ground_truth=None, tool_calls=None
+        ):
+            return 1.0 if dimension.name == "accuracy" else 0.0
+
+        evaluator._evaluate_dimension = fake_dimension_score
+
+        result = evaluator.evaluate({"type": "general"}, "output")
+
+        self.assertAlmostEqual(result["overall_score"], 0.75)
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["dimension_scores"]["accuracy"]["weight"], 0.75)
+        self.assertEqual(result["dimension_scores"]["completeness"]["weight"], 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- fix the weighted-overall calculation in `skills/evaluation/scripts/evaluator.py` so it reads `RubricDimension.weight` from the dataclass instead of treating the rubric entry like a dict
- add a focused regression test that proves a custom weighted rubric now produces the expected overall score
- keep the change isolated to the evaluation framework, independent from the open hosted-agents and context-compression PR lines

## Validation

- `python3 -m py_compile skills/evaluation/scripts/evaluator.py skills/evaluation/tests/test_evaluator.py`
- `python3 -m unittest discover -s skills/evaluation/tests -p "test_evaluator.py"`

## Notes

- `skills/evaluation/scripts/evaluator.py` still carries a large amount of pre-existing basedpyright noise unrelated to this runtime fix; this PR only corrects the dataclass access bug and adds a regression test around it