### PR TITLE
fix: consolidate marketplace to single plugin to fix cache duplication

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,63 +6,29 @@
   },
   "metadata": {
     "description": "Context Engineering skills for building production-grade AI agent systems",
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "plugins": [
     {
-      "name": "context-engineering-fundamentals",
-      "description": "Core context engineering skills covering fundamentals, degradation patterns, compression strategies, and optimization techniques for AI agent systems",
+      "name": "context-engineering",
+      "description": "Comprehensive context engineering skills for building production-grade AI agent systems — covering fundamentals, degradation patterns, compression, optimization, multi-agent coordination, memory systems, tool design, filesystem context, hosted agents, evaluation, project development, and cognitive architecture",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/context-fundamentals",
         "./skills/context-degradation",
         "./skills/context-compression",
-        "./skills/context-optimization"
-      ]
-    },
-    {
-      "name": "agent-architecture",
-      "description": "Multi-agent patterns, memory systems, tool design, filesystem-based context, and hosted agent infrastructure for building production AI agent architectures",
-      "source": "./",
-      "strict": false,
-      "skills": [
+        "./skills/context-optimization",
         "./skills/multi-agent-patterns",
         "./skills/memory-systems",
         "./skills/tool-design",
         "./skills/filesystem-context",
-        "./skills/hosted-agents"
-      ]
-    },
-    {
-      "name": "agent-evaluation",
-      "description": "Evaluation frameworks and LLM-as-judge techniques for testing and validating AI agent systems",
-      "source": "./",
-      "strict": false,
-      "skills": [
+        "./skills/hosted-agents",
         "./skills/evaluation",
-        "./skills/advanced-evaluation"
-      ]
-    },
-    {
-      "name": "agent-development",
-      "description": "Project development methodology for LLM-powered applications including pipeline architecture and batch processing",
-      "source": "./",
-      "strict": false,
-      "skills": [
-        "./skills/project-development"
-      ]
-    },
-    {
-      "name": "cognitive-architecture",
-      "description": "BDI mental state modeling and cognitive architecture patterns for building rational agents with formal belief-desire-intention representations",
-      "source": "./",
-      "strict": false,
-      "skills": [
+        "./skills/advanced-evaluation",
+        "./skills/project-development",
         "./skills/bdi-mental-states"
       ]
     }
   ]
 }
-
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Agent Skills for Context Engineering — an open collection of 13 Agent Skills teaching context engineering principles for production AI agent systems. Skills are platform-agnostic (Claude Code, Cursor, GitHub Copilot, any Open Plugins-conformant tool).
+
+Context engineering is the discipline of curating everything that enters a model's context window (system prompts, tool definitions, retrieved documents, message history, tool outputs) to maximize signal within limited attention budget.
+
+## Repository Structure
+
+- `skills/` — 13 skill directories, each containing a `SKILL.md` with YAML frontmatter (`name`, `description`) and optional `references/` and `scripts/` subdirectories
+- `examples/` — 5 complete demonstration projects (digital-brain-skill, llm-as-judge-skills, book-sft-pipeline, x-to-book-system, interleaved-thinking)
+- `docs/` — Research materials and reference documentation
+- `researcher/` — Research output examples
+- `template/SKILL.md` — Canonical skill template (use when creating new skills)
+- `SKILL.md` (root) — Collection-level metadata and skill map
+- `.claude-plugin/marketplace.json` — Claude Code marketplace manifest (5 bundled plugins)
+- `.plugin/plugin.json` — Open Plugins format manifest (v2.0.0)
+
+## Build & Test Commands
+
+No top-level build system. Individual example projects have their own tooling:
+
+### examples/llm-as-judge-skills (TypeScript, Node >= 18)
+```
+cd examples/llm-as-judge-skills
+npm install
+npm run build        # tsc
+npm test             # vitest (19 tests)
+npm run lint         # eslint
+npm run format       # prettier
+npm run typecheck    # tsc --noEmit
+```
+
+### examples/interleaved-thinking (Python >= 3.10)
+```
+cd examples/interleaved-thinking
+pip install -e ".[dev]"
+pytest               # pytest + pytest-asyncio
+ruff check .         # linting (100 char line length)
+```
+
+### examples/digital-brain-skill (Node.js)
+```
+cd examples/digital-brain-skill
+npm run setup
+npm run weekly-review
+npm run content-ideas
+npm run stale-contacts
+```
+
+## Skill Authoring Rules
+
+When creating or editing skills:
+
+1. **SKILL.md must stay under 500 lines** — move detailed content to `references/` directory
+2. **YAML frontmatter is required** — must include `name` and `description` fields
+3. **Folder naming**: lowercase with hyphens (e.g., `context-fundamentals`)
+4. **Write in third person** — descriptions are injected into system prompts; inconsistent POV causes discovery issues
+5. **Platform-agnostic** — no vendor-locked examples or platform-specific tool names without abstraction
+6. **Token-conscious** — challenge each paragraph: "Does Claude really need this?" Assume advanced audience
+7. **Include a Gotchas section** — experience-derived failure modes are the highest-signal content in any skill
+8. **Update root README.md** when adding new skills
+9. **Update marketplace/plugin manifests** when adding skills (`.claude-plugin/marketplace.json`, `.plugin/plugin.json`)
+
+## Plugin Architecture
+
+All 13 skills are distributed as a single plugin (`context-engineering`) in the marketplace manifest. This avoids cache duplication — Claude Code caches each plugin's `source` directory separately, so multiple plugins pointing to `source: "./"` would each cache a full copy of the repo.
+
+Progressive disclosure pattern: only skill names/descriptions load at startup; full content loads on activation.
+
+## Key Design Principles
+
+- **Context quality over quantity** — attention scarcity and lost-in-middle phenomenon mean more context is not always better
+- **Sub-agents isolate context** — they exist to manage attention budget, not simulate org roles
+- **Skills reference each other** — use plain text skill names (not links) in Integration sections to avoid cross-directory reference issues
+- **Examples use Python pseudocode** — conceptual demonstrations that work across environments, not production-ready implementations

--- a/README.md
+++ b/README.md
@@ -96,33 +96,21 @@ Run this command in Claude Code to register this repository as a plugin source:
 /plugin marketplace add muratcankoylan/Agent-Skills-for-Context-Engineering
 ```
 
-**Step 2: Browse and Install**
+**Step 2: Install the Plugin**
 
-Option A - Browse available plugins:
+Option A - Browse and install:
 1. Select `Browse and install plugins`
 2. Select `context-engineering-marketplace`
-3. Choose a plugin (e.g., `context-engineering-fundamentals`, `agent-architecture`)
+3. Select `context-engineering`
 4. Select `Install now`
 
 Option B - Direct install via command:
 
 ```
-/plugin install context-engineering-fundamentals@context-engineering-marketplace
-/plugin install agent-architecture@context-engineering-marketplace
-/plugin install agent-evaluation@context-engineering-marketplace
-/plugin install agent-development@context-engineering-marketplace
-/plugin install cognitive-architecture@context-engineering-marketplace
+/plugin install context-engineering@context-engineering-marketplace
 ```
 
-### Available Plugins
-
-| Plugin | Skills Included |
-|--------|-----------------|
-| `context-engineering-fundamentals` | context-fundamentals, context-degradation, context-compression, context-optimization |
-| `agent-architecture` | multi-agent-patterns, memory-systems, tool-design, filesystem-context, hosted-agents |
-| `agent-evaluation` | evaluation, advanced-evaluation |
-| `agent-development` | project-development |
-| `cognitive-architecture` | bdi-mental-states |
+This installs all 13 skills in a single plugin. Skills are activated automatically based on your task context.
 
 ### Skill Triggers
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ This repository is listed on the [Cursor Plugin Directory](https://cursor.direct
 
 The `.plugin/plugin.json` manifest follows the [Open Plugins](https://open-plugins.com) standard, so the repo also works with any conformant agent tool (Codex, GitHub Copilot, etc.).
 
+### Using Individual Skills
+
+To use a single skill without installing the full plugin, copy its `SKILL.md` directly into your project's `.claude/skills/` directory:
+
+```bash
+# Example: add just the context-fundamentals skill
+mkdir -p .claude/skills
+curl -o .claude/skills/context-fundamentals.md \
+  https://raw.githubusercontent.com/muratcankoylan/Agent-Skills-for-Context-Engineering/main/skills/context-fundamentals/SKILL.md
+```
+
+Available skills: `context-fundamentals`, `context-degradation`, `context-compression`, `context-optimization`, `multi-agent-patterns`, `memory-systems`, `tool-design`, `filesystem-context`, `hosted-agents`, `evaluation`, `advanced-evaluation`, `project-development`, `bdi-mental-states`
+
 ### For Custom Implementations
 
 Extract the principles and patterns from any skill and implement them in your agent framework. The skills are deliberately platform-agnostic.


### PR DESCRIPTION
## Summary

- **Consolidates 5 bundled plugins into 1 single plugin** (`context-engineering`) containing all 13 skills
- **Fixes duplicate cache and duplicate `/context` entries** reported in #34
- Updates README install instructions to reflect the single-plugin approach
- Adds CLAUDE.md for Claude Code guidance

## Root Cause

All 5 plugins in `marketplace.json` used `"source": "./"`, so Claude Code cached the entire repo separately for each plugin:

```
~/.claude/plugins/cache/context-engineering-marketplace/
├── agent-architecture/          ← 2.42 MB (full repo copy)
├── agent-development/           ← 2.42 MB (full repo copy)
├── agent-evaluation/            ← 2.42 MB (full repo copy)
├── cognitive-architecture/      ← 2.42 MB (full repo copy)
└── context-engineering-fundamentals/ ← 2.42 MB (full repo copy)
```

5 × identical 2,542,084 bytes / 234 files / 110 folders. Skills were also duplicated in `/context` since auto-discovery found all 13 skills in each cached copy.

## Fix

Single plugin → single cache entry → no duplication:

```json
{
  "plugins": [{
    "name": "context-engineering",
    "source": "./",
    "skills": ["./skills/context-fundamentals", ...all 13 skills...]
  }]
}
```

**Install command (new):**
```
/plugin install context-engineering@context-engineering-marketplace
```

## Test plan

- [ ] Verify `marketplace.json` is valid JSON with all 13 skill paths
- [ ] Verify all 13 `SKILL.md` files exist at referenced paths
- [ ] Install via `/plugin marketplace add` + `/plugin install context-engineering@context-engineering-marketplace`
- [ ] Confirm only 1 folder appears in `~/.claude/plugins/cache/context-engineering-marketplace/`
- [ ] Confirm `/context` shows each skill exactly once (no duplicates)
- [ ] Verify skills still activate on their expected triggers

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)