### PR TITLE
add skill-review CI

### DIFF
--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tesslio/skill-review-and-optimize@7a71c6b8ec3eedfd1bffe3638a23cd523b15bc57 # main
+      - uses: tesslio/skill-review-and-optimize@003aa30e36fe3afd9d5fecc861f570d8db8a2e5e # main
         with:
           mode: apply

--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tesslio/skill-review-and-optimize@6f615c6270c03333efdc4370728b342313a72bc1 # main
+      - uses: tesslio/skill-review-and-optimize@e2bc05fb20a1eedc89a58a60a599c10e5544615c # main
         with:
           mode: apply

--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tesslio/skill-review-and-optimize@e31f0626a207c365ccaf1cf3c4dca6ec8ad290ac # main
+      - uses: tesslio/skill-review-and-optimize@d222338446887c0539b0c00ecf58ffd3734692cd # main
         with:
           mode: apply

--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tesslio/skill-review-and-optimize@e2bc05fb20a1eedc89a58a60a599c10e5544615c # main
+      - uses: tesslio/skill-review-and-optimize@e31f0626a207c365ccaf1cf3c4dca6ec8ad290ac # main
         with:
           mode: apply

--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -1,0 +1,21 @@
+name: Apply Skill Optimization
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: tesslio/skill-review-and-optimize@7a71c6b8ec3eedfd1bffe3638a23cd523b15bc57 # main
+        with:
+          mode: apply

--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: tesslio/skill-review-and-optimize@003aa30e36fe3afd9d5fecc861f570d8db8a2e5e # main
+      - uses: tesslio/skill-review-and-optimize@6f615c6270c03333efdc4370728b342313a72bc1 # main
         with:
           mode: apply

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,14 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@14b47c8420ff9ac9a12c30ed4b89ce0e9d0355ae # main


### PR DESCRIPTION
hey @muratcankoylan, following up on #39 (merged, thanks!). adding a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

this means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make! happy to answer any questions on the changes.