### PR TITLE
test: cover rubric dataclass weights in evaluator

### DIFF
--- a/skills/evaluation/scripts/evaluator.py
+++ b/skills/evaluation/scripts/evaluator.py
@@ -211,12 +211,16 @@ class AgentEvaluator:
             if task.get("requires_citations"):
                 # Look for citation patterns like [1], [Author 2024], [source]
                 # Avoid false positives from code brackets or JSON
-                citation_pattern = r'\[\d+\]|\[[A-Z][a-z]+(?:\s+(?:et al\.?|&)\s+[A-Z][a-z]+)?\s*[\d,]+\]|\[(?:source|ref|cite)[^\]]*\]'
+                citation_pattern = r"\[\d+\]|\[[A-Z][a-z]+(?:\s+(?:et al\.?|&)\s+[A-Z][a-z]+)?\s*[\d,]+\]|\[(?:source|ref|cite)[^\]]*\]"
                 import re as _re
+
                 citations_found = _re.findall(citation_pattern, output)
                 if len(citations_found) >= 1:
                     return 1.0
-                elif any(marker in output_lower for marker in ["according to", "cited in", "reported by"]):
+                elif any(
+                    marker in output_lower
+                    for marker in ["according to", "cited in", "reported by"]
+                ):
                     return 0.7
                 return 0.4
             return 0.8  # Citations not required

--- a/skills/evaluation/tests/test_evaluator.py
+++ b/skills/evaluation/tests/test_evaluator.py
@@ -1,0 +1,50 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "evaluator.py"
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "evaluation_evaluator", MODULE_PATH
+)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load evaluator.py from {MODULE_PATH}")
+EVALUATOR = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(EVALUATOR)
+
+
+class AgentEvaluatorTests(unittest.TestCase):
+    def test_weighted_overall_uses_rubric_dimension_weight(self) -> None:
+        rubric = {
+            "accuracy": EVALUATOR.RubricDimension(
+                name="accuracy",
+                weight=0.75,
+                description="Accuracy",
+                levels={},
+            ),
+            "completeness": EVALUATOR.RubricDimension(
+                name="completeness",
+                weight=0.25,
+                description="Completeness",
+                levels={},
+            ),
+        }
+        evaluator = EVALUATOR.AgentEvaluator(rubric=rubric)
+
+        def fake_dimension_score(
+            dimension, task, output, ground_truth=None, tool_calls=None
+        ):
+            return 1.0 if dimension.name == "accuracy" else 0.0
+
+        evaluator._evaluate_dimension = fake_dimension_score
+
+        result = evaluator.evaluate({"type": "general"}, "output")
+
+        self.assertAlmostEqual(result["overall_score"], 0.75)
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["dimension_scores"]["accuracy"]["weight"], 0.75)
+        self.assertEqual(result["dimension_scores"]["completeness"]["weight"], 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression coverage proving `AgentEvaluator` uses each `RubricDimension.weight` when computing the weighted overall score
- lock in the current dataclass-based rubric contract so future refactors do not accidentally fall back to dict-style weight access

## Testing
- `python3 -m unittest skills.evaluation.tests.test_evaluator`