### PR TITLE
fix: avoid duplicate pre-sync write flush in hosted agent session

### DIFF
--- a/skills/hosted-agents/scripts/sandbox_manager.py
+++ b/skills/hosted-agents/scripts/sandbox_manager.py
@@ -515,7 +515,7 @@ class AgentSession:
             # Queue the write
             self.pending_writes.append((path, content))
             await self._wait_for_sync()
-
+            return
         await self.sandbox.write_file(path, content)
 
     def mark_sync_complete(self) -> None:

--- a/skills/hosted-agents/tests/test_sandbox_manager.py
+++ b/skills/hosted-agents/tests/test_sandbox_manager.py
@@ -1,0 +1,38 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "sandbox_manager.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("sandbox_manager", MODULE_PATH)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load sandbox_manager from {MODULE_PATH}")
+SANDBOX_MANAGER = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(SANDBOX_MANAGER)
+
+
+class StubSandbox:
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, str]] = []
+
+    async def write_file(self, path: str, content: str) -> None:
+        self.writes.append((path, content))
+
+
+class AgentSessionWriteTests(unittest.IsolatedAsyncioTestCase):
+    async def test_pre_sync_writes_flush_only_once(self) -> None:
+        sandbox = StubSandbox()
+        session = SANDBOX_MANAGER.AgentSession(sandbox)
+
+        write_task = asyncio.create_task(session.write_file("/tmp/demo.txt", "hello"))
+        await asyncio.sleep(0)
+        session.mark_sync_complete()
+        await write_task
+
+        self.assertEqual(sandbox.writes, [("/tmp/demo.txt", "hello")])
+        self.assertEqual(session.pending_writes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prevent AgentSession.write_file from executing the same write twice when sync completes after queuing
- return immediately after queued writes are flushed by _wait_for_sync
- keep behavior unchanged for already-synced sessions (direct write path)

## Testing
- python3 -m unittest skills/hosted-agents/tests/test_sandbox_manager.py

Replacement for closed #56 after rebasing to latest main.