### PR TITLE
更新: 添加 landing page 预览

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ This repository is cited in academic research as foundational work on static ski
 
 — [Meta Context Engineering via Agentic Skill Evolution](https://arxiv.org/pdf/2601.21557), Peking University State Key Laboratory of General Artificial Intelligence (2026)
 
+## Landing Page Preview
+
+The community has curated a landing page that summarizes the mission and highlights the key skills in this repo. View it live at https://bubbling.dev/api/preview/6098455e-190e-4a2d-8351-b545ffa373f9 or click the preview image below.
+
+![Landing page preview](https://bubbling.dev/api/preview/6098455e-190e-4a2d-8351-b545ffa373f9)
+
 ## Skills Overview
 
 ### Foundational Skills


### PR DESCRIPTION
## Summary
- 回应 #67 请求，在 README 中增加 landing page 预览区块，包含链接与截图让访客快速了解这一带技能的入口
- 明确给出外部预览网址，方便维护者决定是否合并入 README

## Testing
- docs only, no automated tests