### PR TITLE
Add latent briefing skill for KV-based agent memory sharing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "metadata": {
     "description": "Context Engineering skills for building production-grade AI agent systems",
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "plugins": [
     {
       "name": "context-engineering",
-      "description": "Comprehensive context engineering skills for building production-grade AI agent systems — covering fundamentals, degradation patterns, compression, optimization, multi-agent coordination, memory systems, tool design, filesystem context, hosted agents, evaluation, project development, and cognitive architecture",
+      "description": "Comprehensive context engineering skills for building production-grade AI agent systems — covering fundamentals, degradation patterns, compression, optimization, latent briefing (KV sharing between agents), multi-agent coordination, memory systems, tool design, filesystem context, hosted agents, evaluation, advanced evaluation, project development, and cognitive architecture",
       "source": "./",
       "strict": false,
       "skills": [
@@ -27,7 +27,8 @@
         "./skills/evaluation",
         "./skills/advanced-evaluation",
         "./skills/project-development",
-        "./skills/bdi-mental-states"
+        "./skills/bdi-mental-states",
+        "./skills/latent-briefing"
       ]
     }
   ]

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "context-engineering",
-  "description": "Context engineering skills for building production-grade AI agent systems — covering fundamentals, degradation patterns, compression, optimization, multi-agent coordination, memory systems, tool design, evaluation, and more.",
-  "version": "2.0.0",
+  "description": "Context engineering skills for building production-grade AI agent systems — covering fundamentals, degradation patterns, compression, optimization, latent KV sharing between agents, multi-agent coordination, memory systems, tool design, evaluation, and more.",
+  "version": "2.1.0",
   "author": {
     "name": "Muratcan Koylan"
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Agent Skills for Context Engineering — an open collection of 13 Agent Skills teaching context engineering principles for production AI agent systems. Skills are platform-agnostic (Claude Code, Cursor, GitHub Copilot, any Open Plugins-conformant tool).
+Agent Skills for Context Engineering — an open collection of 14 Agent Skills teaching context engineering principles for production AI agent systems. Skills are platform-agnostic (Claude Code, Cursor, GitHub Copilot, any Open Plugins-conformant tool).
 
 Context engineering is the discipline of curating everything that enters a model's context window (system prompts, tool definitions, retrieved documents, message history, tool outputs) to maximize signal within limited attention budget.
 
 ## Repository Structure
 
-- `skills/` — 13 skill directories, each containing a `SKILL.md` with YAML frontmatter (`name`, `description`) and optional `references/` and `scripts/` subdirectories
+- `skills/` — 14 skill directories, each containing a `SKILL.md` with YAML frontmatter (`name`, `description`) and optional `references/` and `scripts/` subdirectories
 - `examples/` — 5 complete demonstration projects (digital-brain-skill, llm-as-judge-skills, book-sft-pipeline, x-to-book-system, interleaved-thinking)
 - `docs/` — Research materials and reference documentation
 - `researcher/` — Research output examples
@@ -67,7 +67,7 @@ When creating or editing skills:
 
 ## Plugin Architecture
 
-All 13 skills are distributed as a single plugin (`context-engineering`) in the marketplace manifest. This avoids cache duplication — Claude Code caches each plugin's `source` directory separately, so multiple plugins pointing to `source: "./"` would each cache a full copy of the repo.
+All 14 skills are distributed as a single plugin (`context-engineering`) in the marketplace manifest. This avoids cache duplication — Claude Code caches each plugin's `source` directory separately, so multiple plugins pointing to `source: "./"` would each cache a full copy of the repo.
 
 Progressive disclosure pattern: only skill names/descriptions load at startup; full content loads on activation.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These skills address the ongoing operation and optimization of agent systems.
 | Skill | Description |
 |-------|-------------|
 | [context-optimization](skills/context-optimization/) | Apply compaction, masking, and caching strategies |
+| [latent-briefing](skills/latent-briefing/) | Share task-relevant orchestrator state with workers via task-guided KV cache compaction when the worker runtime is controllable |
 | [evaluation](skills/evaluation/) | Build evaluation frameworks for agent systems |
 | [advanced-evaluation](skills/advanced-evaluation/) | Master LLM-as-a-Judge techniques: direct scoring, pairwise comparison, rubric generation, and bias mitigation |
 
@@ -112,7 +113,7 @@ Option B - Direct install via command:
 /plugin install context-engineering@context-engineering-marketplace
 ```
 
-This installs all 13 skills in a single plugin. Skills are activated automatically based on your task context.
+This installs all 14 skills in a single plugin. Skills are activated automatically based on your task context.
 
 ### Skill Triggers
 
@@ -122,6 +123,7 @@ This installs all 13 skills in a single plugin. Skills are activated automatical
 | `context-degradation` | "diagnose context problems", "fix lost-in-middle", "debug agent failures" |
 | `context-compression` | "compress context", "summarize conversation", "reduce token usage" |
 | `context-optimization` | "optimize context", "reduce token costs", "implement KV-cache" |
+| `latent-briefing` | "KV cache compaction between agents", "worker KV memory handoff", "latent briefing", "share trajectory without summarization" |
 | `multi-agent-patterns` | "design multi-agent system", "implement supervisor pattern" |
 | `memory-systems` | "implement agent memory", "build knowledge graph", "track entities" |
 | `tool-design` | "design agent tools", "reduce tool complexity", "implement MCP tools" |
@@ -151,7 +153,7 @@ curl -o .claude/skills/context-fundamentals.md \
   https://raw.githubusercontent.com/muratcankoylan/Agent-Skills-for-Context-Engineering/main/skills/context-fundamentals/SKILL.md
 ```
 
-Available skills: `context-fundamentals`, `context-degradation`, `context-compression`, `context-optimization`, `multi-agent-patterns`, `memory-systems`, `tool-design`, `filesystem-context`, `hosted-agents`, `evaluation`, `advanced-evaluation`, `project-development`, `bdi-mental-states`
+Available skills: `context-fundamentals`, `context-degradation`, `context-compression`, `context-optimization`, `latent-briefing`, `multi-agent-patterns`, `memory-systems`, `tool-design`, `filesystem-context`, `hosted-agents`, `evaluation`, `advanced-evaluation`, `project-development`, `bdi-mental-states`
 
 ### For Custom Implementations
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -52,6 +52,9 @@ When agent sessions exhaust memory, compression becomes mandatory. The correct o
 **Context Optimization**
 Techniques include compaction (summarizing context near limits), observation masking (replacing verbose tool outputs with references), prefix caching (reusing KV blocks across requests), and strategic context partitioning (splitting work across sub-agents with isolated contexts).
 
+**Latent Briefing (KV Memory Sharing)**
+Orchestrator-worker systems can compound tokens when supervisors accumulate long trajectories but workers see only narrow text slices. Latent Briefing compacts the orchestrator trajectory in the worker model's KV cache using task-guided attention (Attention Matching-style compaction) so workers receive relevant latent state without full-text replay when the stack exposes worker KV state and the models are compatible.
+
 **Evaluation Frameworks**
 Production agent evaluation requires multi-dimensional rubrics covering factual accuracy, completeness, tool efficiency, and process quality. Effective patterns include LLM-as-judge for scalability, human evaluation for edge cases, and end-state evaluation for agents that mutate persistent state.
 
@@ -86,8 +89,11 @@ Internal skills in this collection:
 - [filesystem-context](skills/filesystem-context/SKILL.md)
 - [hosted-agents](skills/hosted-agents/SKILL.md)
 - [context-optimization](skills/context-optimization/SKILL.md)
+- [latent-briefing](skills/latent-briefing/SKILL.md)
 - [evaluation](skills/evaluation/SKILL.md)
+- [advanced-evaluation](skills/advanced-evaluation/SKILL.md)
 - [project-development](skills/project-development/SKILL.md)
+- [bdi-mental-states](skills/bdi-mental-states/SKILL.md)
 
 External resources on context engineering:
 - Research on attention mechanisms and context window limitations
@@ -99,6 +105,6 @@ External resources on context engineering:
 ## Skill Metadata
 
 **Created**: 2025-12-20
-**Last Updated**: 2025-12-25
+**Last Updated**: 2026-04-14
 **Author**: Agent Skills for Context Engineering Contributors
-**Version**: 1.2.0
+**Version**: 1.3.0

--- a/skills/context-optimization/SKILL.md
+++ b/skills/context-optimization/SKILL.md
@@ -167,6 +167,7 @@ context += [unique_content]  # Unique
 This skill builds on context-fundamentals and context-degradation. It connects to:
 
 - multi-agent-patterns - Partitioning as isolation
+- latent-briefing - Selective KV retention across orchestrator–worker boundaries (compatible models)
 - evaluation - Measuring optimization effectiveness
 - memory-systems - Offloading context to memory
 

--- a/skills/latent-briefing/SKILL.md
+++ b/skills/latent-briefing/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: latent-briefing
+description: This skill should be used when the user asks to "share memory between agents", "KV cache compaction for multi-agent", "orchestrator worker context", "latent briefing", "reduce worker tokens", "cross-agent memory without summarization", or discusses Attention Matching compaction, recursive language models with workers, or token explosion in hierarchical agents.
+---
+
+# Latent Briefing and KV Cache Memory Sharing
+
+Hierarchical multi-agent systems often pay for the same context twice. The orchestrator accumulates a long reasoning trajectory, but each worker usually receives only a narrow text handoff such as a subtask prompt plus raw document slices. Passing the full trajectory fixes coverage but drives token cost up on every worker call. Summarization introduces latency and information loss. Retrieval helps with document access but does not preserve the orchestrator's evolving reasoning state.
+
+Latent Briefing addresses this by sharing memory at the **representation level** rather than the text level. The core idea is to compact the orchestrator trajectory in the worker model's KV cache, keeping positions that are most relevant to the **current worker task**. The method builds on **Attention Matching (AM)** KV cache compaction and adapts it for inference-time multi-agent handoff with task-guided queries, a shared token mask across heads, and robust thresholding.
+
+## When to Activate
+
+Activate this skill when:
+
+- Designing orchestrator-worker or supervisor-specialist systems where workers need access to prior orchestrator state without replaying the full trajectory as text
+- Evaluating alternatives to LLM summarization or RAG for cross-agent state transfer
+- Implementing or studying **KV cache compaction** as a first-class inference primitive, not only prefix caching of identical prompts
+- Debugging token explosion in recursive, hierarchical, or tool-heavy agent graphs
+- Interpreting benchmarks that report worker-token savings, total-token savings, compaction overhead, and accuracy together
+
+## Core Concepts
+
+**The token explosion pattern.** In recursive or REPL-style systems, the orchestrator repeatedly calls a worker to inspect evidence, verify hypotheses, or answer subquestions. The orchestrator's trajectory grows with partial conclusions, dead ends, tool output, and prior worker responses. If that trajectory is passed in full on every worker call, cost compounds quickly.
+
+**Representation-level sharing.** Instead of summarizing the trajectory into natural language, the system operates on the worker model's **KV cache**. It retains the positions that the worker would attend to for the current task and drops the rest. This is more specific than ordinary prefix caching: prefix caching reuses identical prefixes, while Latent Briefing also performs **task-conditioned selective retention** inside the reused trajectory.
+
+**Attention Matching as the compaction engine.** AM seeks a smaller cache whose attention outputs approximate the full cache. Latent Briefing adapts AM for multi-agent inference by changing the scoring signal and batching strategy:
+
+1. Use **task-guided query vectors** derived from the current worker prompt.
+2. Aggregate scores into a **shared global mask** instead of per-head independent subsets.
+3. Use a robust threshold such as `median + tau * MAD` rather than fixed top-k per head.
+
+**Reference result shape.** The public write-up reports substantial worker-token reduction, material total-token savings, and low-single-digit-second compaction overhead on long-document QA workloads. Treat these numbers as workload-specific evidence, not a general guarantee.
+
+## Detailed Topics
+
+### Why Text-Only Mitigations Fall Short
+
+| Approach | Primary weakness |
+|----------|------------------|
+| LLM summarization | High latency, lossy abstraction, and no guarantee the summary preserves what the next subtask needs |
+| Retrieval / RAG | Depends on chunking and embeddings; can miss cross-chunk or cross-step dependencies |
+| Pass full trajectory | Cost scales with every worker call and irrelevant context can degrade worker quality |
+
+Latent Briefing is useful when the bottleneck is not document retrieval itself, but **how to transfer orchestrator state into a worker efficiently and precisely**.
+
+### Recursive Orchestrator-Worker Shape
+
+Frameworks such as **Recursive Language Models** treat long context as an environment and recurse over it: an orchestrator decomposes work and delegates to workers. Latent Briefing fits the gap where the orchestrator has already built task-specific state that should inform the worker, but re-serializing that state as text is too expensive or noisy.
+
+In the ideal setup, the worker maintains a persistent KV state for the orchestrator trajectory. New trajectory tokens extend that state, then compaction runs just before generation for the current subtask.
+
+### Three Inference-Time Modifications
+
+1. **Task-guided query vectors.** Use queries from the current worker task prompt, not generic samples from the context. Forward-pass the trajectory plus current task through the worker model, then score trajectory positions by how strongly the task attends to them.
+
+2. **Shared token selection.** Aggregate scores across layers and heads into one per-position score. One shared mask enables batched operations and avoids hundreds of incompatible per-head solves.
+
+3. **MAD thresholding.** Keep positions above a robust outlier threshold such as `median + tau * MAD`. Higher `tau` is more aggressive. Optimal settings depend on task regime, trajectory quality, and document length.
+
+### Infrastructure Preconditions
+
+Latent Briefing is only practical when the system **controls the worker inference runtime** closely enough to inspect or transform KV state. It is a poor default for API-only stacks where internal KV tensors are inaccessible. It also assumes the orchestrator trajectory can be represented in the worker's model space. If orchestrator and worker differ materially in tokenizer, architecture, or attention layout, direct representation sharing may not be viable.
+
+### Decision Framework
+
+Choose the mechanism that matches the bottleneck:
+
+| Need | Prefer | Why |
+|------|--------|-----|
+| Stable repeated prefix with minimal logic changes | Prefix caching | Cheapest optimization; no information loss |
+| Human-readable and auditable cross-step state | Structured notes or summarization | Easy to inspect and store |
+| Sparse lookup across a large external corpus | Retrieval / RAG | Finds documents efficiently |
+| Worker needs task-specific slices of orchestrator state and runtime access exists | Latent Briefing | Transfers relevant latent state without replaying all text |
+
+Latent Briefing is not a universal replacement for summarization or retrieval. It is a specialized optimization for systems that already run a controllable orchestrator-worker stack.
+
+### Threshold Regimes
+
+Reported long-document QA results suggest:
+
+- **Longer documents:** lighter compaction can preserve broader evidence coverage while still saving tokens.
+- **Harder questions:** more aggressive compaction can help when the orchestrator trajectory contains speculative or low-value branches.
+- **Shorter, easier contexts:** moderate compaction may remove redundancy without dropping needed evidence.
+
+These are tuning hypotheses, not portable laws. Re-measure on the target workload.
+
+## Practical Guidance
+
+- **Define the shared memory boundary first.** Decide exactly what enters the trajectory cache: prior worker replies, tool output, chain-of-thought, or only selected artifacts. Compaction quality depends on what is allowed into the cache in the first place.
+- **Tune on validation data, not anecdotes.** Track task accuracy, worker tokens, total tokens, retention rate, and compaction overhead together.
+- **Measure end-to-end latency.** Compaction only pays off if compaction plus generation beats the best text-layer alternative for the same quality target.
+- **Use strong baselines.** Compare against prefix caching, structured notes, retrieval, and selective text handoff, not only "send everything."
+- **Expect orchestrator variance.** If decomposition strategy changes run to run, average over enough trials to separate compaction effects from orchestrator noise.
+
+## Examples
+
+**Scenario: orchestrator trajectory grows across worker calls**
+
+```text
+Call 1: trajectory T1 -> worker answers subquestion A
+Call 2: trajectory T2 = T1 + new reasoning + reply A
+        compact KV(T2) using the task prompt for B
+        worker answers subquestion B
+```
+
+The task prompt for B decides which parts of `T2` survive into the compacted worker state.
+
+## Guidelines
+
+1. Prefer Latent Briefing when the main waste comes from replaying orchestrator state into workers, not from retrieving source documents.
+2. Prefer plain text handoff when auditability, portability, or closed-model APIs matter more than token efficiency.
+3. Co-design compaction with **evaluation**. A small quality drop can erase large token savings.
+4. Expose compaction aggressiveness as a controlled parameter, not a hidden constant.
+
+## Gotchas
+
+1. **Infrastructure access is the first gate.** If the runtime cannot inspect and rewrite worker KV state, Latent Briefing is a research idea, not a deployable technique.
+2. **Shared model space matters.** KV compaction is defined in a specific model's attention space. Do not assume latent handoff works cleanly across unrelated model families.
+3. **Threshold is workload-dependent.** One global `tau` rarely works across long vs short context and easy vs hard tasks. Expect accuracy cliffs when compaction becomes too aggressive.
+4. **Benchmark scope is narrow.** Public results focus on long-document QA. Code generation, math, and multi-document synthesis may behave differently.
+5. **Orchestrator variance can hide the signal.** A stochastic orchestrator can change the trajectory enough to swamp small compaction gains or losses.
+6. **Weak baselines inflate the apparent win.** Compare against strong text-level alternatives before claiming a system-level advantage.
+
+## Integration
+
+- context-optimization - Prefix caching and observation masking remain the default first moves; Latent Briefing is a more specialized optimization for compatible orchestrator-worker stacks.
+- multi-agent-patterns - Applies when multi-agent token cost is driven by supervisor trajectory replay, not only by coordination overhead.
+- context-compression - Text-layer summaries remain preferable when human-readable state, portability, or audit logs matter.
+- memory-systems - Helps decide when to keep cross-step state in external memory versus in the worker's latent state.
+- tool-design - Worker call shapes and task prompts determine which tokens score highly during compaction.
+
+## References
+
+Internal reference:
+- [Attention Matching formulation and task-guided scoring](./references/attention-matching-formulation.md) - Read when: needing the AM objective, how task-guided scoring changes the query source, or why a shared global mask matters for batching
+
+Related skills in this collection:
+- context-optimization - Read when: the main need is prefix caching, observation masking, or text-layer compaction rather than worker KV manipulation
+- multi-agent-patterns - Read when: deciding whether the architecture should be orchestrator-worker at all
+- context-compression - Read when: human-readable summaries may be a better fit than latent transfer
+- memory-systems - Read when: comparing in-model latent state with external persistent memory
+
+External resources:
+- Ramp Labs announcement: [Latent Briefing: Efficient Memory Sharing for Multi-Agent Systems via KV Cache Compaction](https://x.com/RampLabs/status/2042660310851449223)
+- Attention Matching (AM): [Fast KV Compaction via Attention Matching](https://arxiv.org/abs/2602.16284)
+- Recursive Language Models: [Recursive Language Models](https://arxiv.org/abs/2512.24601)
+
+---
+
+## Skill Metadata
+
+**Created**: 2026-04-14
+**Last Updated**: 2026-04-14
+**Author**: Agent Skills for Context Engineering Contributors; primary technical source Ramp Labs (public post)
+**Version**: 1.1.0

--- a/skills/latent-briefing/references/attention-matching-formulation.md
+++ b/skills/latent-briefing/references/attention-matching-formulation.md
@@ -1,0 +1,62 @@
+# Attention Matching (AM) and Task-Guided Scoring
+
+This note expands the compact treatment in the main skill: the AM objective, what changes under Latent Briefing, and which assumptions matter in practice.
+
+## AM Compaction Objective
+
+Given a full KV cache of size `S`, Attention Matching seeks a smaller cache of size `t < S` whose attention outputs stay close to the original. Per attention head, compacted components `(C1, beta, C2)` satisfy:
+
+```text
+softmax(Q * C1^T + beta) * C2 ~= softmax(Q * K^T) * V
+```
+
+- **C1**: compacted keys, usually a subset of original key vectors selected for high attention mass
+- **beta**: bias corrections so the softmax distribution over kept keys approximates the distribution over all keys
+- **C2**: compacted values reconstructed so the attention output matches the original as closely as possible
+
+The original AM procedure solves each `(layer, head)` independently:
+
+1. Select tokens to keep
+2. Solve `beta`
+3. Reconstruct `C2`
+
+This per-head independence helps quality but makes batching difficult because different heads keep different token subsets.
+
+## What Latent Briefing Changes
+
+Latent Briefing adapts AM for orchestrator-worker handoff:
+
+1. **Query source changes.** Standard AM may score keys using queries sampled from the context itself. Latent Briefing instead uses queries derived from the **current worker task prompt**.
+2. **Scoring becomes task-conditioned.** The trajectory is forward-passed through the worker model, and attention from task queries to trajectory keys defines which positions matter for this worker call.
+3. **Selection becomes shared.** Scores are aggregated across layers and heads into one per-position score so the system can use a single keep/drop mask.
+
+Conceptually:
+
+```text
+trajectory -> K, V
+task prompt -> Q_task
+score(position) = aggregate_attn(Q_task, K[position])
+keep if score(position) exceeds threshold
+```
+
+## Why the Shared Mask Matters
+
+Per-head masks maximize flexibility but force many incompatible small solves. A **shared global mask** makes the retained sequence layout identical across heads, which enables batched tensor operations and much lower latency.
+
+That batching benefit is one of the main reasons Latent Briefing is interesting for inference systems rather than only for offline compression research.
+
+## Thresholding vs Fixed Top-k
+
+Instead of keeping a fixed number of tokens per head, Latent Briefing can threshold the aggregated per-position score distribution:
+
+```text
+keep position i if score[i] > median(score) + k * MAD(score)
+```
+
+This makes retention rate adaptive to the shape of the scores for the current task. Higher `k` means more aggressive compaction.
+
+## Practical Assumptions
+
+- The runtime can inspect and modify worker KV state
+- The worker architecture is stable enough that attention-space retention is meaningful across calls
+- The evaluation tracks both quality and cost, because lower token count alone is not sufficient

--- a/skills/multi-agent-patterns/SKILL.md
+++ b/skills/multi-agent-patterns/SKILL.md
@@ -230,6 +230,7 @@ This skill builds on context-fundamentals and context-degradation. It connects t
 - memory-systems - Shared state management across agents
 - tool-design - Tool specialization per agent
 - context-optimization - Context partitioning strategies
+- latent-briefing - KV-cache trajectory handoff between orchestrator and worker when models align
 
 ## References
 


### PR DESCRIPTION
## Summary
- add a new `latent-briefing` skill covering task-guided KV cache compaction for orchestrator-worker memory sharing
- add a focused reference note on Attention Matching and task-guided scoring, and tighten the skill around deployability constraints, decision criteria, and evaluation guidance
- wire the new skill into collection metadata and related integration points so it is discoverable across the plugin and docs

## Test plan
- [x] Review the new skill and reference files for structure, consistency, and line-budget compliance
- [x] Verify manifests and collection docs reference the new skill consistently
- [x] Check edited files for linter diagnostics
- [ ] Run example-project tests (not applicable; no example code changed)

Made with [Cursor](https://cursor.com)