### PR TITLE
fix: add YAML frontmatter to llm-as-judge agent files

### DIFF
--- a/examples/llm-as-judge-skills/agents/evaluator-agent/evaluator-agent.md
+++ b/examples/llm-as-judge-skills/agents/evaluator-agent/evaluator-agent.md
@@ -1,3 +1,8 @@
+---
+name: evaluator-agent
+description: Assesses quality of LLM-generated responses using direct scoring and pairwise comparison
+---
+
 # Evaluator Agent
 
 ## Purpose

--- a/examples/llm-as-judge-skills/agents/index.md
+++ b/examples/llm-as-judge-skills/agents/index.md
@@ -1,3 +1,8 @@
+---
+name: llm-as-judge-agents
+description: Index of available LLM-as-a-Judge agents: evaluator, researcher, and orchestrator
+---
+
 # Agents Index
 
 Agents are reusable AI components with defined capabilities, tools, and instructions.

--- a/examples/llm-as-judge-skills/agents/orchestrator-agent/orchestrator-agent.md
+++ b/examples/llm-as-judge-skills/agents/orchestrator-agent/orchestrator-agent.md
@@ -1,3 +1,8 @@
+---
+name: orchestrator-agent
+description: Manages complex workflows by delegating tasks to specialized agents and coordinating outputs
+---
+
 # Orchestrator Agent
 
 ## Purpose

--- a/examples/llm-as-judge-skills/agents/research-agent/research-agent.md
+++ b/examples/llm-as-judge-skills/agents/research-agent/research-agent.md
@@ -1,3 +1,8 @@
+---
+name: research-agent
+description: Gathers, verifies, and synthesizes information from multiple sources to answer complex research questions
+---
+
 # Research Agent
 
 ## Purpose


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All four agent files in `examples/llm-as-judge-skills/agents/` are missing required YAML frontmatter (`name` and `description` fields):

- `agents/evaluator-agent/evaluator-agent.md`
- `agents/orchestrator-agent/orchestrator-agent.md`
- `agents/research-agent/research-agent.md`
- `agents/index.md`

Your own `CONTRIBUTING.md` states: *"Each skill must include: YAML frontmatter with `name` and `description` fields"*. Without frontmatter, Claude Code's skill loader cannot register these agents — they are silently invisible to any frontmatter-dependent toolchain.

## Fix

Added a minimal YAML frontmatter block at the top of each file, matching the values that the existing content already implies:

```yaml
---
name: evaluator-agent
description: Assesses quality of LLM-generated responses using direct scoring and pairwise comparison
---
```

No other content was changed. The descriptions are derived directly from each file's own "Purpose" section.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:a3bd793c450299af37da3e5328485a5e14b98fa453eaf28ebf54babdc848665e"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:deb9dd74a4c87c1906aaa63c7084cef47b7190e7ebce8cb161583aae837559d4"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:eed45fdeaf772ea8dbba7e2904bdcabab6ab06c3cf25756a639e91085f98164d"},{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:e3a35252e9c653bc2581883b959d49b07cc69c47d0f01db34731aa104e7227f9"}]}
nlpm-metadata-end -->