### PR TITLE
fix: tighten production dependency ranges from ^ to ~ in package.json

### DIFF
--- a/examples/llm-as-judge-skills/package.json
+++ b/examples/llm-as-judge-skills/package.json
@@ -55,11 +55,11 @@
   },
   "homepage": "https://github.com/muratcankoylan/llm-as-judge-skills#readme",
   "dependencies": {
-    "ai": "^4.0.0",
-    "@ai-sdk/openai": "^1.0.0",
-    "@ai-sdk/anthropic": "^1.0.0",
-    "zod": "^3.23.0",
-    "dotenv": "^16.4.0"
+    "ai": "~4.0.0",
+    "@ai-sdk/openai": "~1.0.0",
+    "@ai-sdk/anthropic": "~1.0.0",
+    "zod": "~3.23.0",
+    "dotenv": "~16.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Low)

All five production dependencies in `examples/llm-as-judge-skills/package.json` use caret (`^`) ranges:

```json
"ai": "^4.0.0",
"@ai-sdk/openai": "^1.0.0",
"@ai-sdk/anthropic": "^1.0.0",
"zod": "^3.23.0",
"dotenv": "^16.4.0"
```

Caret ranges allow npm to automatically install any minor version upgrade (e.g., `4.0.0 → 4.1.0`). If any of these packages is compromised via a supply-chain attack in a minor release, anyone running `npm install` against this manifest picks up the malicious version automatically.

## Fix

Switched all five production dependency ranges from `^` (minor-compatible) to `~` (patch-only):

```json
"ai": "~4.0.0",
"@ai-sdk/openai": "~1.0.0",
"@ai-sdk/anthropic": "~1.0.0",
"zod": "~3.23.0",
"dotenv": "~16.4.0"
```

Tilde ranges still allow patch-level updates (bug fixes and security patches) while blocking automatic minor version upgrades. This is the minimum change that meaningfully reduces supply-chain risk without breaking compatibility or requiring a lockfile update.

Dev dependencies are left unchanged — they are not shipped and the risk profile is lower.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:d1c01a3b5ad2e85dff67b7cd400aa0b8b692b6b5bc72d146601e927f8710cb80"}]}
nlpm-metadata-end -->