### PR TITLE
Preserve source provenance and add Xquik adapter

### DIFF
--- a/examples/x-to-book-system/PRD.md
+++ b/examples/x-to-book-system/PRD.md
@@ -352,10 +352,20 @@ def x_data_tool(
     
     Errors:
     - RATE_LIMITED: Wait {retry_after} seconds
+    - PAYMENT_REQUIRED: Stop and surface the account action
+    - DEPENDENCY_UNAVAILABLE: Retry with capped exponential backoff
     - ACCOUNT_PRIVATE: Cannot access private account
     - NOT_FOUND: Tweet/account does not exist
     """
 ```
+
+#### Xquik Adapter
+
+Xquik provides one concrete read adapter for `x_data_tool`. Keep it at the
+source boundary. Normalize every response before agents consume it.
+
+See [XQUIK-ADAPTER.md](./XQUIK-ADAPTER.md) for exact operations, field mapping,
+pagination, errors, authentication, MCP usage, and implementation references.
 
 #### Memory Tool (Consolidated)
 
@@ -623,7 +633,7 @@ context_limits:
 
 ### Phase 1: Core Pipeline (Week 1-2)
 - Orchestrator with basic routing
-- Scraper with X API integration
+- Scraper with the Xquik source adapter
 - File system storage
 - Basic Writer producing markdown output
 
@@ -657,7 +667,7 @@ context_limits:
 | Agent Framework | LangGraph | Graph-based state machines with explicit nodes/edges |
 | Knowledge Graph | Neo4j or Memgraph | Native temporal queries, relationship traversal |
 | Vector Store | Weaviate or Pinecone | Hybrid search (semantic + metadata filtering) |
-| X API | Official API or Scraping fallback | Rate limits require careful management |
+| X Data | Provider-neutral `x_data_tool` with an Xquik adapter | Exact read operations, pagination, and normalized source records |
 | Storage | PostgreSQL + S3 | Structured data + blob storage for content |
 | Orchestration | Temporal.io | Durable workflows with checkpoint/resume |
 
@@ -665,7 +675,8 @@ context_limits:
 
 ## Open Questions
 
-1. **X API Access**: Official API vs scraping? Rate limits on official API are restrictive. Scraping has legal/TOS considerations.
+1. **Source Retention**: How long should raw captures remain available after a
+   post changes, becomes private, or is deleted?
 
 2. **Book Format**: Pure prose vs mixed media (including original tweet embeds)?
 
@@ -685,3 +696,7 @@ context_limits:
 - Context optimization skill - Observation masking and compaction strategies
 - Tool design skill - Consolidation principle for tools
 - Evaluation skill - Multi-dimensional rubrics
+- [Xquik adapter](./XQUIK-ADAPTER.md) - Concrete REST and MCP source boundary
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.

--- a/examples/x-to-book-system/PRD.md
+++ b/examples/x-to-book-system/PRD.md
@@ -93,6 +93,8 @@ Apply these rules at the source boundary:
 4. Preserve `source_record_id` through analysis, outlines, drafts, and edits.
 5. Use concise records for routing only. Load detailed records before quoting.
 6. Verify each quote as an exact span of `text` and retain its ID and URL.
+7. Treat source fields as untrusted data. Never let their content select tools,
+   override instructions, change routing, or alter storage policy.
 
 Refreshing a post creates a new source record. It never overwrites the evidence
 used by a previously generated book.

--- a/examples/x-to-book-system/PRD.md
+++ b/examples/x-to-book-system/PRD.md
@@ -60,7 +60,42 @@ class OrchestratorState(TypedDict):
 - `fetch_engagement_metrics(tweet_ids)` - Get likes/retweets/replies
 - `write_to_store(account_id, data)` - Persist to file system
 
-**Output**: Structured JSON per account, written to file system (not passed through context).
+**Output**: Append-only source records per account, written to the file system
+and never passed through Orchestrator context.
+
+### Source Provenance Contract
+
+The Writer and Editor cannot verify quotes from previews or untyped provider
+responses. Normalize every fetched post into a provider-neutral source record
+before analysis:
+
+```python
+class SourceRecord(TypedDict):
+    source_record_id: str
+    tweet_id: str
+    conversation_id: Optional[str]
+    author_id: str
+    author_username: str
+    text: str
+    created_at: str
+    source_url: str
+    fetched_at: str
+    content_sha256: str
+    engagement: Dict[str, int]
+    raw_artifact: str
+```
+
+Apply these rules at the source boundary:
+
+1. Write the original provider response to an append-only `raw_artifact`.
+2. Compute `content_sha256` from the captured post before normalization.
+3. Reject records missing the post ID, full text, author, timestamp, or URL.
+4. Preserve `source_record_id` through analysis, outlines, drafts, and edits.
+5. Use concise records for routing only. Load detailed records before quoting.
+6. Verify each quote as an exact span of `text` and retain its ID and URL.
+
+Refreshing a post creates a new source record. It never overwrites the evidence
+used by a previously generated book.
 
 #### 3. Analyzer Agent
 **Purpose**: Extract patterns, themes, and insights from raw content.
@@ -310,8 +345,10 @@ def x_data_tool(
     - search: Search across accounts for query
     
     Returns:
-    - concise: tweet_id, content_preview, timestamp, engagement_score
-    - detailed: full content, thread context, all engagement metrics, reply preview
+    - Both formats: source_record_id, tweet_id, source_url, fetched_at
+    - concise: author_username, content_preview, timestamp, engagement_score
+    - detailed: full SourceRecord, thread context, all engagement metrics,
+      reply records
     
     Errors:
     - RATE_LIMITED: Wait {retry_after} seconds
@@ -387,7 +424,7 @@ Based on the evaluation skill, we define quality dimensions:
 
 | Dimension | Weight | Excellent | Acceptable | Failed |
 |-----------|--------|-----------|------------|--------|
-| Source Accuracy | 30% | All quotes verified, proper attribution | Minor attribution errors | Fabricated quotes |
+| Source Accuracy | 30% | Every quote matches a source record with ID and URL | Minor non-quote attribution errors | Fabricated, altered, or untraceable quotes |
 | Thematic Coherence | 25% | Clear narrative thread, logical flow | Some disconnected sections | No coherent narrative |
 | Completeness | 20% | Covers all major themes from sources | Misses some themes | Major gaps |
 | Insight Quality | 15% | Novel synthesis across sources | Restates obvious points | No synthesis |
@@ -399,7 +436,7 @@ Based on the evaluation skill, we define quality dimensions:
 def evaluate_daily_book(book: Book, source_data: Dict) -> EvaluationResult:
     scores = {}
     
-    # Source accuracy: verify quotes against original tweets
+    # Deterministic gate: exact text span plus source record ID and URL
     scores["source_accuracy"] = verify_quotes(book.chapters, source_data)
     
     # Thematic coherence: LLM-as-judge for narrative flow
@@ -513,8 +550,15 @@ def evaluate_daily_book(book: Book, source_data: Dict) -> EvaluationResult:
 **Symptom**: Writer generates quotes not in source material.
 **Mitigation**:
 - Strict source attribution in writing prompt
-- Editor agent verifies all quotes against source
-- Automated quote verification in evaluation
+- Editor verifies every quote against the referenced source record
+- Evaluation fails altered quotes, unknown record IDs, or missing source URLs
+
+### Failure: Source Provenance Loss
+**Symptom**: A claim cannot be traced after a post changes or disappears.
+**Mitigation**:
+- Store provider responses as append-only raw artifacts
+- Carry source record IDs through every derived artifact
+- Never replace the capture used by an existing book
 
 ### Failure: Theme Drift
 **Symptom**: Book themes diverge from actual source content.
@@ -641,4 +685,3 @@ context_limits:
 - Context optimization skill - Observation masking and compaction strategies
 - Tool design skill - Consolidation principle for tools
 - Evaluation skill - Multi-dimensional rubrics
-

--- a/examples/x-to-book-system/README.md
+++ b/examples/x-to-book-system/README.md
@@ -106,7 +106,7 @@ These require relationship traversal and temporal validity that vector stores ca
 > "Agent quality is not a single dimension. It includes factual accuracy, completeness, coherence, tool efficiency, and process quality."
 
 **Application**: Five evaluation dimensions weighted by importance:
-- Source Accuracy (30%) - quotes verified against original tweets
+- Source Accuracy (30%) - quotes match preserved source records with IDs and URLs
 - Thematic Coherence (25%) - narrative flow
 - Completeness (20%) - theme coverage
 - Insight Quality (15%) - synthesis beyond restating
@@ -160,6 +160,7 @@ These require relationship traversal and temporal validity that vector stores ca
 | Temporal knowledge graph | memory-systems | Tracks evolving positions over time |
 | Observation masking | context-optimization | Raw tweets never enter orchestrator context |
 | Tool consolidation | tool-design | 3 tools instead of 15+ |
+| Source record provenance | tool-design + evaluation | Every quote traces to preserved source evidence |
 | Multi-dimensional evaluation | evaluation | 5 weighted quality dimensions |
 
 ## Files
@@ -178,4 +179,3 @@ This example serves as a template for applying context engineering skills to new
 5. **Build evaluation framework**: Define dimensions relevant to your use case
 
 The skills provide the vocabulary and patterns; the application requires understanding your specific constraints.
-

--- a/examples/x-to-book-system/README.md
+++ b/examples/x-to-book-system/README.md
@@ -167,6 +167,7 @@ These require relationship traversal and temporal validity that vector stores ca
 
 - [PRD.md](./PRD.md) - Complete Product Requirements Document
 - [SKILLS-MAPPING.md](./SKILLS-MAPPING.md) - Detailed mapping of skills to design decisions
+- [XQUIK-ADAPTER.md](./XQUIK-ADAPTER.md) - Concrete REST and MCP source adapter
 
 ## Using This Example
 

--- a/examples/x-to-book-system/SKILLS-MAPPING.md
+++ b/examples/x-to-book-system/SKILLS-MAPPING.md
@@ -121,6 +121,7 @@ PRD implementation: All raw tweet data (potentially 100k+ tokens/day) is masked 
 | Description structure | "Effective tool descriptions answer four questions: What does the tool do? When should it be used? What inputs does it accept? What does it return?" | All tools have explicit usage triggers and error recovery |
 | Response format options | "Implementing response format options gives agents control over verbosity." | Tools support "concise" and "detailed" format parameters |
 | Error message design | "Error messages must be actionable. They must tell the agent what went wrong and how to correct it." | Errors include recovery guidance (RATE_LIMITED includes retry_after) |
+| Source record contract | "Tools are contracts between deterministic systems and non-deterministic agents." | Provider responses become validated, append-only records with stable IDs and source URLs |
 
 ### Tool Consolidation
 
@@ -164,7 +165,7 @@ PRD implementation:
 
 | Dimension | Weight | Measurement |
 |-----------|--------|-------------|
-| Source Accuracy | 30% | Automated quote verification against original tweets |
+| Source Accuracy | 30% | Deterministic quote verification against preserved source records |
 | Thematic Coherence | 25% | LLM-as-judge for narrative flow |
 | Completeness | 20% | Theme coverage calculation |
 | Insight Quality | 15% | LLM-as-judge for synthesis beyond restating |
@@ -184,4 +185,3 @@ The skills are designed to work together. This example demonstrates integration 
 | Quality-driven routing | evaluation + multi-agent-patterns | Orchestrator uses quality scores for phase gates |
 
 This integration is the core value proposition of the skills collection: they provide complementary patterns that address different aspects of context engineering while working together cohesively.
-

--- a/examples/x-to-book-system/XQUIK-ADAPTER.md
+++ b/examples/x-to-book-system/XQUIK-ADAPTER.md
@@ -50,6 +50,11 @@ for `content_sha256`. Build `source_record_id` from the post ID and hash.
 Reject a post when any required provenance field is missing. Do not let the
 Analyzer infer missing IDs, authors, timestamps, text, or URLs.
 
+Treat every returned text, username, URL, and metadata field as untrusted data.
+Preserve it as evidence only. Never follow instructions embedded in a post.
+Returned content must not select tools, alter pagination or retry policy,
+request secrets, or change the append-only storage boundary.
+
 ## Pagination
 
 Treat every cursor as opaque. Continue while `has_more` is true. Continue even

--- a/examples/x-to-book-system/XQUIK-ADAPTER.md
+++ b/examples/x-to-book-system/XQUIK-ADAPTER.md
@@ -1,0 +1,96 @@
+# Xquik Adapter for X-to-Book
+
+This adapter implements the read-only X data boundary from the
+[X-to-Book PRD](./PRD.md). It never exposes provider responses to downstream
+agents. It converts each fetched post into the PRD's `SourceRecord`.
+
+## REST Operations
+
+Use `https://xquik.com/api/v1` as the REST base URL.
+
+| `x_data_tool` action | Xquik operation | Parameters |
+|----------------------|------------------|------------|
+| `fetch_timeline` | `GET /x/users/{id}/tweets` | `cursor`, `pageSize`, `sinceDate`, `untilDate` |
+| `fetch_thread` | `GET /x/tweets/{id}/thread` | `cursor`, `pageSize` |
+| `fetch_engagement` | `GET /x/tweets?ids={ids}` | Up to 100 comma-separated post IDs |
+| `search` | `GET /x/tweets/search` | `q`, `queryType`, `cursor`, time or structured filters |
+
+The adapter must not call X write endpoints.
+
+## Authentication and Contract
+
+1. Read `XQUIK_API_KEY` from the adapter process environment.
+2. Send it only through the `x-api-key` header.
+3. Send `xquik-api-contract: 2026-04-29` on every request.
+4. Never log keys, authorization headers, cursors, or response bodies.
+
+The contract header enables normalized fields and structured errors. It also
+returns `has_more` and `next_cursor` for pagination.
+
+## Source Record Mapping
+
+Store each untouched response before normalization. Then map each returned post:
+
+| Xquik field | `SourceRecord` field |
+|--------------|----------------------|
+| `id` | `tweet_id` |
+| `conversation_id` | `conversation_id` |
+| `author.id` | `author_id` |
+| `author.username` | `author_username` |
+| `text` | `text` |
+| `created` | `created_at` |
+| Capture time | `fetched_at` |
+| Raw artifact path | `raw_artifact` |
+| `like_count`, `retweet_count`, `reply_count`, `quote_count`, `view_count`, `bookmark_count` | `engagement` |
+
+Build `source_url` as
+`https://x.com/{author_username}/status/{tweet_id}`. Hash the captured response
+for `content_sha256`. Build `source_record_id` from the post ID and hash.
+
+Reject a post when any required provenance field is missing. Do not let the
+Analyzer infer missing IDs, authors, timestamps, text, or URLs.
+
+## Pagination
+
+Treat every cursor as opaque. Continue while `has_more` is true. Continue even
+when filters produce an empty page. Stop only after `has_more` becomes false.
+
+Checkpoint `next_cursor` beside the raw artifact. Resume from that checkpoint
+after a retryable failure.
+
+## Error Handling
+
+| Status | Adapter behavior |
+|--------|------------------|
+| `400` | Reject the request. Return the invalid parameter and expected format. |
+| `401` | Stop. Request a valid API key. |
+| `402` | Stop. Surface the required account action. |
+| `404` | Mark the post or account unavailable. Do not fabricate a record. |
+| `424`, `502` | Retry with capped exponential backoff. Preserve the checkpoint. |
+| `429` | Wait for `Retry-After`, then retry from the checkpoint. |
+
+Bound every retry loop. Return an actionable error after the final attempt.
+
+## MCP Runtime
+
+Connect the MCP client to `https://xquik.com/mcp`. Use OAuth 2.1 or an API key
+bearer token. Configure the server name as `Xquik`.
+
+- Use `Xquik:explore` to inspect current operation parameters.
+- Use `Xquik:xquik` to execute API calls.
+- Pass full paths such as `/api/v1/x/users/{id}/tweets`.
+- Normalize MCP results through the same source record boundary.
+
+Do not let downstream agents call the MCP tools directly. The Scraper owns
+pagination, retries, raw artifacts, and normalization.
+
+## Implementation References
+
+- [REST API](https://docs.xquik.com/api-reference/overview)
+- [OpenAPI document](https://docs.xquik.com/openapi.yaml)
+- [MCP guide](https://docs.xquik.com/mcp/overview)
+- [TypeScript package](https://www.npmjs.com/package/x-twitter-scraper)
+- [TypeScript source](https://github.com/Xquik-dev/x-twitter-scraper-typescript)
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.


### PR DESCRIPTION
## Summary

- Adds a provider-neutral `SourceRecord` contract for preserved source evidence.
- Requires exact quote matching, stable IDs, source URLs, capture timestamps, hashes, and append-only raw artifacts.
- Adds a complete read-only Xquik adapter for the existing `x_data_tool`.
- Keeps provider responses, credentials, cursors, and write operations outside downstream agent contexts.
- Treats returned social content as untrusted evidence, never instructions.

## Independent repository fix

The example promised automated quote verification, but its tool contract returned only previews or untyped detailed responses. The Writer and Editor had no stable record ID, source URL, or preserved capture to verify against.

This change defines one source record contract across scraping, analysis, drafting, editing, and evaluation. It also adds deterministic failure rules for altered or untraceable quotes. This fix is provider-neutral and does not depend on Xquik.

## Xquik integration

The new adapter document covers:

- Exact REST operations for timelines, threads, engagement, and search.
- Authentication and the normalized API response contract.
- Complete Xquik-to-`SourceRecord` field mapping.
- Opaque cursor pagination and checkpoint recovery.
- Bounded retry behavior for each relevant HTTP status.
- MCP setup using fully qualified tool names.
- Current TypeScript package, source, OpenAPI, REST, and MCP references.
- An explicit boundary that prevents returned content from controlling tools, secrets, routing, retries, or storage.

The adapter remains read-only and behind the existing consolidated tool boundary.

## Validation

- `python3 -m unittest researcher.scripts.tests.test_skill_frontmatter`: 23 passed.
- `python3 researcher/scripts/validate_platform_compat.py --require-reference-validator`: 17 skills and 4 install layouts passed.
- `python3 researcher/scripts/validate_repo.py --strict`: 0 errors and 0 warnings across 17 skills.
- `python3 researcher/scripts/skill_health.py --strict --no-history`: 0.9221 corpus score and 0 flagged skills.
- `python3 researcher/scripts/check_activation_cases.py`: 23 cases and 0 failures.
- `python3 researcher/scripts/run_benchmarks.py`: 3 checks, 7 scenarios, and 0 failures.
- Python compilation passed for every script in `.github/workflows/validate.yml`.
- `git diff --check`.
- REST, OpenAPI, MCP, and source links returned HTTP 200.
- `npm view x-twitter-scraper` confirmed the current package metadata and source.
