### PR TITLE
Fix path traversal and arbitrary file deletion in pipeline_template.py

### DIFF
--- a/skills/project-development/scripts/pipeline_template.py
+++ b/skills/project-development/scripts/pipeline_template.py
@@ -37,6 +37,9 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+# Strict allow-list for batch identifiers to prevent path traversal.
+_BATCH_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
 __all__ = [
     "Item",
     "ParsedResult",
@@ -129,12 +132,48 @@ class ParsedResult:
 # Path Utilities
 # -----------------------------------------------------------------------------
 
+def _validate_batch_id(batch_id: str) -> str:
+    """Validate and normalize a batch identifier.
+
+    Rejects empty values, non-string values, and any characters outside the
+    strict allow-list of alphanumerics, underscore, and hyphen. This prevents
+    path traversal via batch IDs such as ``../../etc``.
+    """
+    if not isinstance(batch_id, str):
+        raise ValueError(f"batch_id must be a string, got {type(batch_id).__name__}")
+    if not batch_id:
+        raise ValueError("batch_id must not be empty")
+    if not _BATCH_ID_RE.match(batch_id):
+        raise ValueError(
+            f"batch_id contains invalid characters: {batch_id!r}. "
+            "Only A-Z, a-z, 0-9, underscore, and hyphen are allowed."
+        )
+    return batch_id
+
+
+def _resolve_within(root: Path, subpath: Path) -> Path:
+    """Resolve ``subpath`` and verify it is contained within ``root``.
+
+    Raises ``ValueError`` if the resolved path escapes ``root``.
+    """
+    root_resolved = root.resolve()
+    target_resolved = subpath.resolve()
+    try:
+        target_resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ValueError(
+            f"Resolved path {target_resolved} is outside allowed root {root_resolved}"
+        ) from exc
+    return target_resolved
+
+
 def get_batch_dir(batch_id: str) -> Path:
     """Get the data directory for a batch.
 
     Use when: resolving the root directory for a specific batch run.
     """
-    return DATA_DIR / batch_id
+    batch_id = _validate_batch_id(batch_id)
+    return _resolve_within(DATA_DIR, DATA_DIR / batch_id)
 
 
 def get_item_dir(batch_id: str, item_id: str) -> Path:
@@ -150,7 +189,8 @@ def get_output_dir(batch_id: str) -> Path:
 
     Use when: writing final rendered outputs (HTML, reports, etc.).
     """
-    return OUTPUT_DIR / batch_id
+    batch_id = _validate_batch_id(batch_id)
+    return _resolve_within(OUTPUT_DIR, OUTPUT_DIR / batch_id)
 
 
 # -----------------------------------------------------------------------------

--- a/skills/project-development/scripts/tests/test_pipeline_path_validation.py
+++ b/skills/project-development/scripts/tests/test_pipeline_path_validation.py
@@ -1,0 +1,111 @@
+"""Path validation tests for the pipeline template.
+
+Run directly or via the standard library test runner:
+
+    python -m unittest skills/project-development/scripts/tests/test_pipeline_path_validation.py
+    python skills/project-development/scripts/tests/test_pipeline_path_validation.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "pipeline_template.py"
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "pipeline_template", MODULE_PATH
+)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"Unable to load pipeline_template.py from {MODULE_PATH}")
+PIPELINE = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(PIPELINE)
+
+
+class BatchIdValidationTests(unittest.TestCase):
+    """Tests for batch_id sanitization in get_batch_dir and get_output_dir."""
+
+    def test_valid_batch_ids_accepted(self) -> None:
+        valid_ids = [
+            "2025-01-15",
+            "batch_2025",
+            "abc-123_DEF",
+            "a",
+            "A0-9_z",
+        ]
+        for batch_id in valid_ids:
+            with self.subTest(batch_id=batch_id):
+                batch_dir = PIPELINE.get_batch_dir(batch_id)
+                output_dir = PIPELINE.get_output_dir(batch_id)
+                self.assertIn(batch_id, batch_dir.name)
+                self.assertIn(batch_id, output_dir.name)
+
+    def test_dotdot_rejected(self) -> None:
+        for batch_id in ["..", "../etc", "../../tmp", "foo/../bar"]:
+            with self.subTest(batch_id=batch_id):
+                with self.assertRaises(ValueError):
+                    PIPELINE.get_batch_dir(batch_id)
+                with self.assertRaises(ValueError):
+                    PIPELINE.get_output_dir(batch_id)
+
+    def test_path_separators_rejected(self) -> None:
+        for batch_id in [
+            "foo/bar",
+            "foo\\bar",
+            "/foo",
+            "\\foo",
+            "foo/bar/baz",
+        ]:
+            with self.subTest(batch_id=batch_id):
+                with self.assertRaises(ValueError):
+                    PIPELINE.get_batch_dir(batch_id)
+                with self.assertRaises(ValueError):
+                    PIPELINE.get_output_dir(batch_id)
+
+    def test_empty_batch_id_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            PIPELINE.get_batch_dir("")
+        with self.assertRaises(ValueError):
+            PIPELINE.get_output_dir("")
+
+    def test_non_string_batch_id_rejected(self) -> None:
+        for batch_id in [None, 123, 1.5, ["batch"], {"id": "batch"}]:  # type: ignore[assignment]
+            with self.subTest(batch_id=batch_id):
+                with self.assertRaises(ValueError):
+                    PIPELINE.get_batch_dir(batch_id)  # type: ignore[arg-type]
+                with self.assertRaises(ValueError):
+                    PIPELINE.get_output_dir(batch_id)  # type: ignore[arg-type]
+
+
+class DeletionSafetyRegressionTests(unittest.TestCase):
+    """Regression tests ensuring stage_clean cannot escape DATA_DIR."""
+
+    def setUp(self) -> None:
+        self.original_data_dir = PIPELINE.DATA_DIR
+        self.temp_root = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_root.cleanup)
+        PIPELINE.DATA_DIR = Path(self.temp_root.name) / "data"
+
+    def tearDown(self) -> None:
+        PIPELINE.DATA_DIR = self.original_data_dir
+
+    def test_stage_clean_does_not_delete_outside_data_dir(self) -> None:
+        # Create a target directory outside the configured DATA_DIR and place a
+        # file that must survive any clean attempt.
+        outside_dir = Path(self.temp_root.name) / "outside"
+        outside_dir.mkdir(parents=True)
+        sentinel = outside_dir / "sentinel.txt"
+        sentinel.write_text("must survive")
+
+        # A traversal batch_id must be rejected before any filesystem mutation.
+        with self.assertRaises(ValueError):
+            PIPELINE.stage_clean("../outside")
+
+        self.assertTrue(sentinel.exists(), "stage_clean escaped DATA_DIR and deleted files")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

get_batch_dir(batch_id) previously constructed DATA_DIR / batch_id without validating atch_id. Because stage_clean walks atch_dir / <item_dir> and deletes files, a batch ID such as ../../other-directory could delete files outside DATA_DIR.

## Changes

- Added strict allow-list validation for atch_id: [A-Za-z0-9_-]+.
- Added containment check: the resolved batch directory must be a child of the resolved DATA_DIR.
- Applied the same validation to get_output_dir to prevent analogous writes outside OUTPUT_DIR.
- Added unit tests covering valid IDs, path separators, .., empty IDs, non-string IDs, and a deletion-safety regression test.

## Risk and trade-offs

- Existing batch IDs containing dots, spaces, or slashes will now raise ValueError. This is intentional: the allow-list closes the traversal surface.
- The fix uses Path.resolve() for both parent and child, so symlink-based escapes are also rejected by the elative_to check.

## Validation

- python -m unittest skills/project-development/scripts/tests/test_pipeline_path_validation.py -- 6 tests passed
- python skills/project-development/scripts/pipeline_template.py estimate --batch-id 2025-01-15 -- ran successfully
- python researcher/scripts/validate_repo.py --strict -- passed (0 errors, 0 warnings, 17 skills)