### PR TITLE
Update retired Sonnet 4 model id in pipeline template

### DIFF
--- a/skills/project-development/scripts/pipeline_template.py
+++ b/skills/project-development/scripts/pipeline_template.py
@@ -24,7 +24,7 @@ Programmatic usage:
     from pipeline_template import stage_acquire, stage_prepare, stage_process
     stage_acquire("2025-01-15", limit=5)
     stage_prepare("2025-01-15")
-    stage_process("2025-01-15", model="claude-sonnet-4-20250514", max_workers=3)
+    stage_process("2025-01-15", model="claude-sonnet-4-6", max_workers=3)
 """
 
 import argparse
@@ -270,7 +270,7 @@ def generate_prompt(item_data: dict[str, Any]) -> str:
 
 def stage_process(
     batch_id: str,
-    model: str = "claude-sonnet-4-20250514",
+    model: str = "claude-sonnet-4-6",
     max_workers: int = 5,
 ) -> list[tuple[str, int, str | None]]:
     """Stage 3: Execute LLM calls (the expensive, non-deterministic stage).
@@ -755,7 +755,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--model",
-        default="claude-sonnet-4-20250514",
+        default="claude-sonnet-4-6",
         help="Model to use for processing",
     )
     parser.add_argument(


### PR DESCRIPTION
`claude-sonnet-4-20250514` was retired on 15 June 2026, so a request that passes it now comes back as a 404 model error. The pipeline template uses it as the default model in three places.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `skills/project-development/scripts/pipeline_template.py` | 27 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `skills/project-development/scripts/pipeline_template.py` | 273 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `skills/project-development/scripts/pipeline_template.py` | 758 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |

Retirement dates are listed at https://platform.claude.com/docs/en/about-claude/model-deprecations

Scope is narrow on purpose. Only the model string changed, nothing else in the file was touched, and I left the two `.md` example agents alone because the same string there sits inside example code where you may want the original text preserved.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run the code against the API to reproduce a failure, the claim rests on the published retirement dates. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.