### PR TITLE
docs(spec-003): authorize classification invariant amendment

### DIFF
--- a/docs/decisions/0007-amend-spec-003-classification-and-reference-invariants.md
+++ b/docs/decisions/0007-amend-spec-003-classification-and-reference-invariants.md
@@ -1,0 +1,45 @@
+# ADR-0007: Amend SPEC-003 classification and reference invariants
+
+- Status: accepted
+- Date: 2026-08-15
+- Spec: SPEC-003
+- Lifecycle transition: SPEC-003@1 -> amended -> SPEC-003@2
+
+## Context
+
+SPEC-003 revision 1 established portable schema, identity, reference, envelope, storage, freeze, credential-reference, and legacy-migration contracts. Adversarial review of the merged implementation reproduced three gaps in its registry-aware validation boundary:
+
+1. an `ArtifactRef` can target itself or another meta-reference, so a reference chain can evade the intended terminal-target boundary;
+2. a public reference or envelope can name or contain a target whose registered classification is more restrictive, silently lowering the classification of the same content; and
+3. a legacy-origin reference can name a target kind whose schema permits only native UUIDv7 identity, creating a reference to an impossible durable record.
+
+These are contract defects, not merely implementation bugs. Revision 1 says classification cannot silently fall and that references bind target kind, version, prefix, and origin through the registry, but it does not state the closed reference graph and classification relation precisely enough for independent runtimes to converge on the same rejection behavior.
+
+## Decision
+
+SPEC-003 revision 1 enters the terminal `amended` state and names `SPEC-003@2` as its only replacement. Revision 2 must preserve the existing runtime-neutral registry and identity architecture while making the following invariants normative and cross-runtime:
+
+- reference targets form a closed, acyclic graph; self-reference and undeclared meta-reference chains fail closed;
+- an envelope, reference, or resolved target may retain or raise classification under one declared ordering, but it may never lower the classification of the same content;
+- target identity origin is validated against the target schema contract, not inferred only from UUID shape or a caller-supplied origin label;
+- public event or review surfaces cannot use an intermediate `ArtifactRef` or `ArtifactEnvelope` to launder a private target classification; and
+- Python and TypeScript execute the same adversarial vectors and stable error codes for these invariants.
+
+This decision authorizes only the lifecycle transition. It does not accept revision 2, modify schema bytes, or authorize implementation. The replacement must enter as a digest-linked draft and proceed through the normal architecture-review and acceptance transitions before code changes are eligible for implementation.
+
+## Consequences
+
+- Existing revision-1 bytes remain preserved in Git history and cannot be rewritten in place.
+- Any record accepted only through the ambiguous reference behavior is not grandfathered into revision 2; it must be revalidated or quarantined.
+- Later event, journal, graph, context, evaluation, and deployment specifications may rely on the corrected boundary only after revision 2 is accepted and implemented.
+- The implementation PR must include Python and TypeScript parity, adversarial laundering fixtures, generated schema evidence, deterministic inventory regeneration, and public-boundary validation.
+
+## Alternatives considered
+
+- Patch validators without revising SPEC-003. Rejected because two conforming runtimes could otherwise make different decisions while both claiming revision-1 compliance.
+- Allow bounded recursive references. Rejected for revision 2 because no current accepted contract requires them and recursive resolution adds cycle, availability, classification, and denial-oracle complexity.
+- Treat classification as an unchecked annotation on references. Rejected because the public/private boundary would then depend on every downstream consumer remembering to resolve and reclassify the target.
+
+## Verification
+
+The transition PR must change only lifecycle metadata in SPEC-003, add this one-purpose accepted ADR, update its index, regenerate deterministic inventory outputs, and pass the base-aware lifecycle validator against the exact parent branch. The successor and implementation PRs must supply the contract and runtime tests described above.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,3 +18,4 @@ The dependency-ordered implementation contracts live in the [specification progr
 - [ADR-0004: Make schemas, identity, and frozen bytes runtime-neutral](0004-runtime-neutral-artifact-contracts.md)
 - [ADR-0005: Publish one machine-checked specification program](0005-canonical-specification-program.md)
 - [ADR-0006: Validate the complete public release boundary](0006-validate-public-release-boundary.md)
+- [ADR-0007: Amend SPEC-003 classification and reference invariants](0007-amend-spec-003-classification-and-reference-invariants.md)

--- a/docs/specs/SPEC-003-schema-registry.md
+++ b/docs/specs/SPEC-003-schema-registry.md
@@ -1,6 +1,6 @@
 # SPEC-003: Schema registry and artifact identity
 
-Status: implemented
+Status: amended
 Revision: 1
 Revises: none
 Wave: 0
@@ -9,6 +9,8 @@ Owners: platform steward agent; human maintainer
 Depends on: SPEC-001, SPEC-002
 Dependency revisions: SPEC-001@1, SPEC-002@1
 Adoption decision: ADR-0005
+Lifecycle decision: ADR-0007
+Replacement: SPEC-003@2
 
 ## Decision
 

--- a/researcher/corpus/inventory.json
+++ b/researcher/corpus/inventory.json
@@ -241,7 +241,7 @@
       ]
     },
     "architecture_decisions": {
-      "count": 6,
+      "count": 7,
       "lifecycle": [
         "accepted",
         "deprecated",
@@ -348,6 +348,19 @@
           ],
           "status": "accepted",
           "title": "Validate the complete public release boundary"
+        },
+        {
+          "date": "2026-08-15",
+          "digest": "sha256:c18b5ec24e8745bd5267bbce48e3510e3223dbeb48d9ac59bf2d0b8644338cc9",
+          "id": "ADR-0007",
+          "lifecycle_transition": "SPEC-003@1 -> amended -> SPEC-003@2",
+          "path": "docs/decisions/0007-amend-spec-003-classification-and-reference-invariants.md",
+          "spec_scope": "SPEC-003",
+          "specifications": [
+            "SPEC-003"
+          ],
+          "status": "accepted",
+          "title": "Amend SPEC-003 classification and reference invariants"
         }
       ]
     },
@@ -2333,16 +2346,18 @@
             "SPEC-002"
           ],
           "dependency_revisions": "SPEC-001@1, SPEC-002@1",
-          "digest": "sha256:95a91c9356d2f6f3c3ba13086e882020511faf2f0403da7fb833c142677a96d0",
+          "digest": "sha256:8850f070fcf92d644da30d606cb2f11eb63ed7e9ae2c22b73aab5a185ba01f7f",
           "id": "SPEC-003",
+          "lifecycle_decision": "ADR-0007",
           "owners": [
             "platform steward agent",
             "human maintainer"
           ],
           "path": "docs/specs/SPEC-003-schema-registry.md",
+          "replacement": "SPEC-003@2",
           "revises": "none",
           "revision": 1,
-          "status": "implemented",
+          "status": "amended",
           "title": "Schema registry and artifact identity",
           "wave": 0
         },
@@ -3408,12 +3423,12 @@
     ]
   },
   "repository_revision": {
-    "digest": "sha256:e18fe120351ed7519d1173ca04526db8b5242186ff9b8ae7a70d0e16f9a7671d",
+    "digest": "sha256:2cfc43c9223d424b976ff5058aa40b3a0751eb60d3c1e1564c5cd7ba61835b97",
     "git_commit_excluded_to_avoid_self_reference": true,
     "kind": "canonical_source_tree"
   },
   "schema_version": "1.0.0",
-  "source_tree_digest": "sha256:e18fe120351ed7519d1173ca04526db8b5242186ff9b8ae7a70d0e16f9a7671d",
+  "source_tree_digest": "sha256:2cfc43c9223d424b976ff5058aa40b3a0751eb60d3c1e1564c5cd7ba61835b97",
   "sources": [
     {
       "digest": "sha256:2aebace36e5bbdd8ad93bc9c7563a0c673787838eb0f4f62a5376132d43ce616",
@@ -3466,9 +3481,14 @@
       "size_bytes": 3850
     },
     {
-      "digest": "sha256:27812a440a9561fee0679331e7dc7ed7ec6dca6d8cd90b06282f7d56719b3d3a",
+      "digest": "sha256:c18b5ec24e8745bd5267bbce48e3510e3223dbeb48d9ac59bf2d0b8644338cc9",
+      "path": "docs/decisions/0007-amend-spec-003-classification-and-reference-invariants.md",
+      "size_bytes": 4166
+    },
+    {
+      "digest": "sha256:387ae76622f6c99e38e81f5bc588d4bf41b3028fce9b3ec9719459ff28e6c921",
       "path": "docs/decisions/README.md",
-      "size_bytes": 2050
+      "size_bytes": 2183
     },
     {
       "digest": "sha256:9d903133d4523f42aebdaacad1d825b4e364d608102bc68af2245637db632746",
@@ -3496,9 +3516,9 @@
       "size_bytes": 3600
     },
     {
-      "digest": "sha256:95a91c9356d2f6f3c3ba13086e882020511faf2f0403da7fb833c142677a96d0",
+      "digest": "sha256:8850f070fcf92d644da30d606cb2f11eb63ed7e9ae2c22b73aab5a185ba01f7f",
       "path": "docs/specs/SPEC-003-schema-registry.md",
-      "size_bytes": 7189
+      "size_bytes": 7238
     },
     {
       "digest": "sha256:d5c4f86026b617ed94d79b702d3f88cf6c0f53da316677156dd5deda6009eac5",

--- a/researcher/generated/corpus-summary.md
+++ b/researcher/generated/corpus-summary.md
@@ -4,13 +4,13 @@
 This is a generated view of canonical repository artifacts, not a second source of truth.
 
 - Schema: `1.0.0`
-- Source tree: `sha256:e18fe120351ed7519d1173ca04526db8b5242186ff9b8ae7a70d0e16f9a7671d`
+- Source tree: `sha256:2cfc43c9223d424b976ff5058aa40b3a0751eb60d3c1e1564c5cd7ba61835b97`
 - Unresolved references: `0`
 
 | Artifact | Count |
 | --- | ---: |
 | Specifications | 27 |
-| Architecture decisions | 6 |
+| Architecture decisions | 7 |
 | Orchestration briefs | 7 |
 | Published skills | 17 |
 | Mechanism registry records | 22 |

--- a/researcher/scripts/tests/test_build_inventory.py
+++ b/researcher/scripts/tests/test_build_inventory.py
@@ -303,10 +303,10 @@ class RepositoryInventoryTests(unittest.TestCase):
     def test_architecture_decisions_are_inventory_backed(self) -> None:
         inventory = InventoryBuilder(ROOT).build()
         decisions = inventory["artifacts"]["architecture_decisions"]
-        self.assertEqual(decisions["count"], 6)
+        self.assertEqual(decisions["count"], 7)
         self.assertEqual(
             {record["id"] for record in decisions["records"]},
-            {f"ADR-{number:04d}" for number in range(1, 7)},
+            {f"ADR-{number:04d}" for number in range(1, 8)},
         )
 
     def test_orchestration_briefs_are_inventory_backed_and_non_authoritative(self) -> None:
@@ -698,11 +698,11 @@ class RepositoryInventoryTests(unittest.TestCase):
     def test_active_specification_binds_every_direct_dependency_revision(self) -> None:
         temporary, root = self.fixture()
         self.addCleanup(temporary.cleanup)
-        path = root / "docs/specs/SPEC-003-schema-registry.md"
+        path = root / "docs/specs/SPEC-001-repository-reconciliation.md"
         original = path.read_text(encoding="utf-8")
         mutated = original.replace(
-            "Dependency revisions: SPEC-001@1, SPEC-002@1",
-            "Dependency revisions: SPEC-001@1",
+            "Dependency revisions: SPEC-000@1",
+            "Dependency revisions: none",
             1,
         )
         self.assertNotEqual(original, mutated)


### PR DESCRIPTION
## Summary

- move SPEC-003 revision 1 from `implemented` to terminal `amended`
- add accepted one-purpose ADR-0007 for the exact transition `SPEC-003@1 -> amended -> SPEC-003@2`
- reserve `SPEC-003@2` as the only replacement
- update the ADR index, deterministic inventory, generated summary, and count/status fixtures

## Stack

This PR is stacked on #122 at `0030fdbf8da082f8029972cbe04140c12ce508e7`, which is stacked on roadmap PR #121.

Do not merge this PR before #121 and #122. After each parent merges, retarget the next child and verify that the effective diff remains this one lifecycle-decision commit.

## Scope boundary

This PR changes no SPEC-003 contract body, schema, validator, artifact store, or runtime code. ADR-0007 authorizes only the human-merged terminal transition. It does not accept revision 2 or authorize implementation.

The terminal SPEC-003 bytes have digest:

`sha256:8850f070fcf92d644da30d606cb2f11eb63ed7e9ae2c22b73aab5a185ba01f7f`

A future revision-2 draft must bind that exact digest after this PR is human-merged. It must then pass separate architecture-review and acceptance transitions before implementation.

## Evidence

- 282 Python tests passed
- lifecycle validation passed against exact base `0030fdb`
- inventory check passed: 301 artifacts, 177 canonical sources, digest `2cfc43c9223d`
- governance, schema, export, public-repository, platform, strict-repository, skill-health, benchmark, and activation gates passed
- independent read-only review found no blocker or high finding
- staged diff and 157-commit history Gitleaks scans passed

## Merge requirements

- [ ] parent PR #121 is human-merged
- [ ] parent PR #122 is retargeted, revalidated, and human-merged
- [ ] GitHub validation passes on exact head `48e17e8`
- [ ] human reviewer confirms the transition remains isolated from revision-2 contract or code changes
