### PR TITLE
docs(spec-000): authorize authority vocabulary amendment

### DIFF
--- a/docs/decisions/0008-amend-spec-000-for-a-closed-authority-vocabulary.md
+++ b/docs/decisions/0008-amend-spec-000-for-a-closed-authority-vocabulary.md
@@ -1,0 +1,42 @@
+# ADR-0008: Amend SPEC-000 for a closed authority vocabulary
+
+- Status: accepted
+- Date: 2026-08-15
+- Spec: SPEC-000
+- Lifecycle transition: SPEC-000@1 -> amended -> SPEC-000@2
+
+## Context
+
+SPEC-000 revision 1 established a deterministic, deny-by-default constitution and human-only merge, amendment, private-export, credential-destination, and weight-training authority. The later specification program makes durable state changes through typed event families whose append boundary must match an authenticated policy decision and runtime grant.
+
+The revision-1 constitution does not define a complete, versioned catalog for those state-changing action and resource pairs. Treating every later command family as an ad hoc policy edit would make cross-spec review and replay ambiguous. Reusing broad research or execution permissions for protected effects would create privilege escalation paths, while leaving new effects unlisted would make accepted downstream contracts impossible to implement under default deny.
+
+The roadmap therefore introduced a pre-Wave-1 requirement for a digest-pinned authority vocabulary, exact actor and maximum-effect profiles, mandatory decision context, dependency floors, grant operations, and executable allow and deny fixtures. That requirement changes the normative authority contract and cannot be added to an implemented revision in place.
+
+## Decision
+
+SPEC-000 revision 1 enters the terminal `amended` state and names `SPEC-000@2` as its only replacement. Revision 2 must retain deny-by-default and human-only merge authority while defining one closed, machine-validated authority catalog for every state-changing or privileged effect known to the specification program, plus an explicitly separate nonmutating read layer.
+
+The replacement contract must bind the catalog schema, version, canonical path, and exact digest. It must require an exhaustive fixture manifest and, before implementation, a deterministic conformance receipt proving that the effective constitution neither denies declared valid operations nor permits undeclared or widened operations. Unknown pairs, inactive dependency owners, wrong actors, missing guards, widened effects, wrong grants, alternate permissive rules, and state-changing use of read authority must fail closed.
+
+This decision authorizes only the lifecycle transition. It does not accept revision 2, create the registry, change the effective constitution, or authorize any runtime operation. Revision 2 must enter as a digest-linked draft and complete architecture review and acceptance before implementation.
+
+## Consequences
+
+- The current revision-1 constitution and policy remain historical implementation evidence; no existing rule is silently reinterpreted as a revision-2 authority profile.
+- The exact currently effective `governance/constitution.yaml` remains the sole decision oracle under the prior policy until a successor is human-merged and becomes effective; this terminal specification decision neither revokes that oracle nor grants revision-2 authority.
+- SPEC-004 and later revisions cannot enter architecture review until a human-merged SPEC-000 revision 2 supplies the validated registry and exact dependency floor required by the lifecycle gate.
+- Authority-vocabulary changes are constitutional revisions with explicit downstream impact, not an ordinary runtime extension mechanism.
+- The revision-2 implementation must close the policy allow-rule set structurally and execute cross-product negative cases, rather than relying only on a finite happy-path fixture list.
+- Human merge, default-branch update, production activation, private export, credential administration, hidden evaluation, journal recovery, and weight training remain distinct protected effects.
+
+## Alternatives considered
+
+- Keep adding unregistered action strings to the YAML policy. Rejected because runtime event families and independent validators could not prove that they resolve to the same bounded authority semantics.
+- Reuse broad `execute_work` or `research` permissions for later control-plane effects. Rejected because that would let a general executor acquire merge, recovery, credential, evaluation, or deployment authority by choosing a different resource label.
+- Treat the registry as authority by itself. Rejected because the constitution decision, exact runtime grant, target and version guards, owner reducer, and dependency floor must all independently allow the effect.
+- Patch the lifecycle validator without revising SPEC-000. Rejected because the validator would then enforce a contract absent from the authoritative specification.
+
+## Verification
+
+The transition PR must change only lifecycle metadata in SPEC-000, add this one-purpose accepted ADR, update its index, regenerate deterministic inventory outputs, and pass the base-aware lifecycle validator against the exact parent branch. The revision-2 draft and implementation must separately supply registry, fixture, policy-closure, conformance-receipt, migration, rollback, and cross-surface parity evidence.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -19,3 +19,4 @@ The dependency-ordered implementation contracts live in the [specification progr
 - [ADR-0005: Publish one machine-checked specification program](0005-canonical-specification-program.md)
 - [ADR-0006: Validate the complete public release boundary](0006-validate-public-release-boundary.md)
 - [ADR-0007: Amend SPEC-003 classification and reference invariants](0007-amend-spec-003-classification-and-reference-invariants.md)
+- [ADR-0008: Amend SPEC-000 for a closed authority vocabulary](0008-amend-spec-000-for-a-closed-authority-vocabulary.md)

--- a/docs/specs/SPEC-000-program-constitution.md
+++ b/docs/specs/SPEC-000-program-constitution.md
@@ -1,6 +1,6 @@
 # SPEC-000: Program constitution and authority model
 
-Status: implemented
+Status: amended
 Revision: 1
 Revises: none
 Wave: 0
@@ -9,6 +9,8 @@ Owners: human maintainer; governance agent
 Depends on: none
 Dependency revisions: none
 Adoption decision: ADR-0005
+Lifecycle decision: ADR-0008
+Replacement: SPEC-000@2
 
 ## Decision
 

--- a/researcher/corpus/inventory.json
+++ b/researcher/corpus/inventory.json
@@ -241,7 +241,7 @@
       ]
     },
     "architecture_decisions": {
-      "count": 7,
+      "count": 8,
       "lifecycle": [
         "accepted",
         "deprecated",
@@ -361,6 +361,19 @@
           ],
           "status": "accepted",
           "title": "Amend SPEC-003 classification and reference invariants"
+        },
+        {
+          "date": "2026-08-15",
+          "digest": "sha256:7cd0c1bb5bcc706f684ff94c2cdf5f9f75bb2cf7780e478d566189d85b161e79",
+          "id": "ADR-0008",
+          "lifecycle_transition": "SPEC-000@1 -> amended -> SPEC-000@2",
+          "path": "docs/decisions/0008-amend-spec-000-for-a-closed-authority-vocabulary.md",
+          "spec_scope": "SPEC-000",
+          "specifications": [
+            "SPEC-000"
+          ],
+          "status": "accepted",
+          "title": "Amend SPEC-000 for a closed authority vocabulary"
         }
       ]
     },
@@ -2285,16 +2298,18 @@
           "classification": "public",
           "dependencies": [],
           "dependency_revisions": "none",
-          "digest": "sha256:be3255f4de01abd3f3326d88916ea9d10e14b364bf7d08ca62eb3093d6e215bf",
+          "digest": "sha256:80fd43dd017a100a23c758e7ae6a22e9b266a19ba3c39573545eddffcb80f784",
           "id": "SPEC-000",
+          "lifecycle_decision": "ADR-0008",
           "owners": [
             "human maintainer",
             "governance agent"
           ],
           "path": "docs/specs/SPEC-000-program-constitution.md",
+          "replacement": "SPEC-000@2",
           "revises": "none",
           "revision": 1,
-          "status": "implemented",
+          "status": "amended",
           "title": "Program constitution and authority model",
           "wave": 0
         },
@@ -3423,12 +3438,12 @@
     ]
   },
   "repository_revision": {
-    "digest": "sha256:2cfc43c9223d424b976ff5058aa40b3a0751eb60d3c1e1564c5cd7ba61835b97",
+    "digest": "sha256:1f922e2f5367b661a66b3f98c554cb4826799967b05e0aa95d669a4e435bf88c",
     "git_commit_excluded_to_avoid_self_reference": true,
     "kind": "canonical_source_tree"
   },
   "schema_version": "1.0.0",
-  "source_tree_digest": "sha256:2cfc43c9223d424b976ff5058aa40b3a0751eb60d3c1e1564c5cd7ba61835b97",
+  "source_tree_digest": "sha256:1f922e2f5367b661a66b3f98c554cb4826799967b05e0aa95d669a4e435bf88c",
   "sources": [
     {
       "digest": "sha256:2aebace36e5bbdd8ad93bc9c7563a0c673787838eb0f4f62a5376132d43ce616",
@@ -3486,9 +3501,14 @@
       "size_bytes": 4166
     },
     {
-      "digest": "sha256:387ae76622f6c99e38e81f5bc588d4bf41b3028fce9b3ec9719459ff28e6c921",
+      "digest": "sha256:7cd0c1bb5bcc706f684ff94c2cdf5f9f75bb2cf7780e478d566189d85b161e79",
+      "path": "docs/decisions/0008-amend-spec-000-for-a-closed-authority-vocabulary.md",
+      "size_bytes": 5065
+    },
+    {
+      "digest": "sha256:7d63cb14b72fce45637a0b6ca48fb887d63320d220ee55f4c13fb6c0fda0e33a",
       "path": "docs/decisions/README.md",
-      "size_bytes": 2183
+      "size_bytes": 2304
     },
     {
       "digest": "sha256:9d903133d4523f42aebdaacad1d825b4e364d608102bc68af2245637db632746",
@@ -3501,9 +3521,9 @@
       "size_bytes": 33175
     },
     {
-      "digest": "sha256:be3255f4de01abd3f3326d88916ea9d10e14b364bf7d08ca62eb3093d6e215bf",
+      "digest": "sha256:80fd43dd017a100a23c758e7ae6a22e9b266a19ba3c39573545eddffcb80f784",
       "path": "docs/specs/SPEC-000-program-constitution.md",
-      "size_bytes": 2803
+      "size_bytes": 2852
     },
     {
       "digest": "sha256:e6109fb747cffc920d3fe48c9bab939bdc9ce7d0dd1130f5ce50367b4d218e28",

--- a/researcher/generated/corpus-summary.md
+++ b/researcher/generated/corpus-summary.md
@@ -4,13 +4,13 @@
 This is a generated view of canonical repository artifacts, not a second source of truth.
 
 - Schema: `1.0.0`
-- Source tree: `sha256:2cfc43c9223d424b976ff5058aa40b3a0751eb60d3c1e1564c5cd7ba61835b97`
+- Source tree: `sha256:1f922e2f5367b661a66b3f98c554cb4826799967b05e0aa95d669a4e435bf88c`
 - Unresolved references: `0`
 
 | Artifact | Count |
 | --- | ---: |
 | Specifications | 27 |
-| Architecture decisions | 7 |
+| Architecture decisions | 8 |
 | Orchestration briefs | 7 |
 | Published skills | 17 |
 | Mechanism registry records | 22 |

--- a/researcher/scripts/tests/test_build_inventory.py
+++ b/researcher/scripts/tests/test_build_inventory.py
@@ -150,9 +150,15 @@ def write_generic_spec000_revision_two(root: Path, *, status: str = "accepted") 
     original_bytes = path.read_bytes()
     prior_digest = f"sha256:{hashlib.sha256(original_bytes).hexdigest()}"
     text = original_bytes.decode("utf-8")
-    text = text.replace("Status: implemented", f"Status: {status}", 1)
+    if "Status: amended\n" in text:
+        text = text.replace("Status: amended", f"Status: {status}", 1)
+    else:
+        text = text.replace("Status: implemented", f"Status: {status}", 1)
     text = text.replace("Revision: 1", "Revision: 2", 1)
     text = text.replace("Revises: none", f"Revises: {prior_digest}", 1)
+    text = text.replace("Adoption decision: ADR-0005\n", "", 1)
+    text = text.replace("Lifecycle decision: ADR-0008\n", "", 1)
+    text = text.replace("Replacement: SPEC-000@2\n", "", 1)
     path.write_text(text, encoding="utf-8")
 
 
@@ -303,10 +309,10 @@ class RepositoryInventoryTests(unittest.TestCase):
     def test_architecture_decisions_are_inventory_backed(self) -> None:
         inventory = InventoryBuilder(ROOT).build()
         decisions = inventory["artifacts"]["architecture_decisions"]
-        self.assertEqual(decisions["count"], 7)
+        self.assertEqual(decisions["count"], 8)
         self.assertEqual(
             {record["id"] for record in decisions["records"]},
-            {f"ADR-{number:04d}" for number in range(1, 8)},
+            {f"ADR-{number:04d}" for number in range(1, 9)},
         )
 
     def test_orchestration_briefs_are_inventory_backed_and_non_authoritative(self) -> None:


### PR DESCRIPTION
## Summary

- move SPEC-000 revision 1 from `implemented` to terminal `amended`
- add accepted one-purpose ADR-0008 for `SPEC-000@1 -> amended -> SPEC-000@2`
- reserve revision 2 for the digest-pinned closed authority vocabulary and executable policy-conformance contract
- preserve the exact current constitution as the sole decision oracle throughout the amendment gap
- update the ADR index, deterministic inventory, generated summary, and revision-2 fixture helper

## Stack

This PR is stacked on #123 at `48e17e8b7de61925a644ad5e62f5609525bcadc0`, above #122 and roadmap PR #121.

Do not merge this PR before its parent chain. After each parent merges, retarget the child and confirm this PR remains one lifecycle-decision commit.

## Scope and authority boundary

This PR changes no constitution YAML, policy rule, authority registry, schema, runtime code, or effective grant. ADR-0008 authorizes only the human-merged terminal lifecycle transition.

The exact current `governance/constitution.yaml` remains the sole decision oracle until a human-merged successor becomes effective. This PR neither revokes current policy nor grants revision-2 authority.

The terminal SPEC-000 bytes have digest:

`sha256:80fd43dd017a100a23c758e7ae6a22e9b266a19ba3c39573545eddffcb80f784`

A future SPEC-000@2 draft must bind that exact digest, then complete architecture review and acceptance before registry or policy implementation.

## Evidence

- 282 Python tests passed
- lifecycle validation passed against exact base `48e17e8`
- inventory check passed: 302 artifacts, 178 canonical sources, digest `1f922e2f5367`
- all 2,142 governance decisions passed
- schema, export, public-repository, platform, strict-repository, skill-health, benchmark, and activation gates passed
- independent read-only reviews found no blocker or high finding
- staged candidate and 158-commit history Gitleaks scans passed

## Merge requirements

- [ ] PRs #121, #122, and #123 are human-merged in order
- [ ] GitHub validation passes on exact head `c917805`
- [ ] human reviewer confirms no revision-2 contract, policy, or runtime change is bundled
