### PR TITLE
docs(spec-001): authorize snapshot identity amendment

### DIFF
--- a/docs/decisions/0009-amend-spec-001-for-exact-repository-snapshot-identity.md
+++ b/docs/decisions/0009-amend-spec-001-for-exact-repository-snapshot-identity.md
@@ -1,0 +1,46 @@
+# ADR-0009: Amend SPEC-001 for exact repository snapshot identity
+
+- Status: accepted
+- Date: 2026-08-15
+- Spec: SPEC-001
+- Lifecycle transition: SPEC-001@1 -> amended -> SPEC-001@2
+
+## Context
+
+SPEC-001 revision 1 established the canonical repository inventory, deterministic source-tree digest, generated corpus summary, closed reference checks, and atomic regeneration. Its `source_tree_digest` intentionally excludes the generated inventory and summary so those outputs do not hash themselves.
+
+That digest is an identity for the canonical source set, not an identity for a Git repository snapshot. Later control-plane contracts must bootstrap repository acceptance from one exact protected commit and tree while proving that the checked inventory was generated from those same bytes. A Git commit alone does not prove the inventory relation, and a source-tree digest alone does not identify the Git object format, commit, tree, or repository history boundary. Treating either value as both identities would let independent implementations accept different repository states under the same claimed bootstrap evidence.
+
+SPEC-000 revision 1 is also entering its amendment lifecycle. SPEC-001 revision 1 is frozen to `SPEC-000@1`; it cannot advance against the replacement constitution without its own revision and exact dependency binding.
+
+## Decision
+
+SPEC-001 revision 1 enters the terminal `amended` state and names `SPEC-001@2` as its only replacement. Revision 2 must preserve the checked derived-view architecture while defining a non-self-referential repository snapshot evidence contract that:
+
+- keeps canonical-source-tree identity distinct from Git repository identity;
+- binds the Git object format, exact commit object, exact tree object, exact inventory bytes, inventory schema and builder versions, and the inventory's declared `source_tree_digest`;
+- verifies that every registered canonical source byte is the byte reachable from the bound tree and that generated files do not become inputs to their own digest;
+- rejects dirty, untracked, sparse, submodule, symlink, index-flag, ancestry-rewrite, or mixed-snapshot ambiguity unless a later accepted contract explicitly defines the case;
+- remains deterministic across repository locations and process restarts; and
+- grants no repository acceptance, merge, deployment, or runtime authority merely because snapshot evidence validates.
+
+The replacement must bind the current accepted constitution revision through the ordinary dependency-revision lifecycle. Repository acceptance and accepted-public-commit transitions remain owned by their later specifications and human authority boundaries.
+
+This decision authorizes only the lifecycle transition. It does not accept revision 2, define its final schema, change inventory bytes, bootstrap repository acceptance, or authorize implementation.
+
+## Consequences
+
+- Existing revision-1 inventory and summary artifacts remain valid as deterministic derived views; they are not retroactively reinterpreted as Git acceptance receipts.
+- Downstream journal, work-order, command, and reconciliation contracts may consume exact repository snapshot evidence only after revision 2 is accepted and implemented.
+- The successor implementation must include clean-tree and adversarial repository-state fixtures, deterministic regeneration, rollback, and validation that snapshot evidence cannot become an authority token.
+- SPEC-001 must be revised before it can advance against `SPEC-000@2` or satisfy later same-stage dependency floors.
+
+## Alternatives considered
+
+- Use `git rev-parse HEAD` as the inventory identity. Rejected because ambient HEAD can differ from the reviewed tree and does not prove inventory derivation.
+- Treat `source_tree_digest` as a Git commit identity. Rejected because it intentionally covers a different byte set and excludes generated outputs to avoid self-reference.
+- Add an implementation-only receipt without revising SPEC-001. Rejected because independent conforming implementations would still lack one normative identity relation.
+
+## Verification
+
+The transition PR must change only lifecycle metadata in SPEC-001, add this one-purpose accepted ADR, update its index, move the active dependency-binding inventory fixture to another active specification, regenerate deterministic inventory outputs, and pass the base-aware lifecycle validator against the exact parent branch. The successor and implementation PRs must separately provide the contract, fixtures, migration, rollback, and authority-separation evidence described above.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -20,3 +20,4 @@ The dependency-ordered implementation contracts live in the [specification progr
 - [ADR-0006: Validate the complete public release boundary](0006-validate-public-release-boundary.md)
 - [ADR-0007: Amend SPEC-003 classification and reference invariants](0007-amend-spec-003-classification-and-reference-invariants.md)
 - [ADR-0008: Amend SPEC-000 for a closed authority vocabulary](0008-amend-spec-000-for-a-closed-authority-vocabulary.md)
+- [ADR-0009: Amend SPEC-001 for exact repository snapshot identity](0009-amend-spec-001-for-exact-repository-snapshot-identity.md)

--- a/docs/specs/SPEC-001-repository-reconciliation.md
+++ b/docs/specs/SPEC-001-repository-reconciliation.md
@@ -1,6 +1,6 @@
 # SPEC-001: Repository reconciliation and generated corpus inventory
 
-Status: implemented
+Status: amended
 Revision: 1
 Revises: none
 Wave: 0
@@ -9,6 +9,8 @@ Owners: corpus steward agent; human maintainer
 Depends on: SPEC-000
 Dependency revisions: SPEC-000@1
 Adoption decision: ADR-0005
+Lifecycle decision: ADR-0009
+Replacement: SPEC-001@2
 
 ## Decision
 

--- a/researcher/corpus/inventory.json
+++ b/researcher/corpus/inventory.json
@@ -241,7 +241,7 @@
       ]
     },
     "architecture_decisions": {
-      "count": 8,
+      "count": 9,
       "lifecycle": [
         "accepted",
         "deprecated",
@@ -374,6 +374,19 @@
           ],
           "status": "accepted",
           "title": "Amend SPEC-000 for a closed authority vocabulary"
+        },
+        {
+          "date": "2026-08-15",
+          "digest": "sha256:eb7ebbffb816d5ee9a55b6a7a9e122673ea41e832291d12e37a867f4c249f13f",
+          "id": "ADR-0009",
+          "lifecycle_transition": "SPEC-001@1 -> amended -> SPEC-001@2",
+          "path": "docs/decisions/0009-amend-spec-001-for-exact-repository-snapshot-identity.md",
+          "spec_scope": "SPEC-001",
+          "specifications": [
+            "SPEC-001"
+          ],
+          "status": "accepted",
+          "title": "Amend SPEC-001 for exact repository snapshot identity"
         }
       ]
     },
@@ -2440,16 +2453,18 @@
             "SPEC-000"
           ],
           "dependency_revisions": "SPEC-000@1",
-          "digest": "sha256:e6109fb747cffc920d3fe48c9bab939bdc9ce7d0dd1130f5ce50367b4d218e28",
+          "digest": "sha256:cd27da25b87b3e8ee6e03a1febe0be4a3fd9688972fbb8edc02161518090320f",
           "id": "SPEC-001",
+          "lifecycle_decision": "ADR-0009",
           "owners": [
             "corpus steward agent",
             "human maintainer"
           ],
           "path": "docs/specs/SPEC-001-repository-reconciliation.md",
+          "replacement": "SPEC-001@2",
           "revises": "none",
           "revision": 1,
-          "status": "implemented",
+          "status": "amended",
           "title": "Repository reconciliation and generated corpus inventory",
           "wave": 0
         },
@@ -3574,12 +3589,12 @@
     ]
   },
   "repository_revision": {
-    "digest": "sha256:86862cd0d756cea633504f0553603296f441daba2d08c9686a87d4ce334a597d",
+    "digest": "sha256:00bcaa9f84dd6ffa4e3e02944b7d76f4cc7465bfac5e15f711c2b6ace9fa793f",
     "git_commit_excluded_to_avoid_self_reference": true,
     "kind": "canonical_source_tree"
   },
   "schema_version": "1.0.0",
-  "source_tree_digest": "sha256:86862cd0d756cea633504f0553603296f441daba2d08c9686a87d4ce334a597d",
+  "source_tree_digest": "sha256:00bcaa9f84dd6ffa4e3e02944b7d76f4cc7465bfac5e15f711c2b6ace9fa793f",
   "sources": [
     {
       "digest": "sha256:2aebace36e5bbdd8ad93bc9c7563a0c673787838eb0f4f62a5376132d43ce616",
@@ -3642,9 +3657,14 @@
       "size_bytes": 5065
     },
     {
-      "digest": "sha256:7d63cb14b72fce45637a0b6ca48fb887d63320d220ee55f4c13fb6c0fda0e33a",
+      "digest": "sha256:eb7ebbffb816d5ee9a55b6a7a9e122673ea41e832291d12e37a867f4c249f13f",
+      "path": "docs/decisions/0009-amend-spec-001-for-exact-repository-snapshot-identity.md",
+      "size_bytes": 4576
+    },
+    {
+      "digest": "sha256:0a90fc31db983de9dbc1918f80ded7c25a1a7214bcd3ed035f7c35fff54477a3",
       "path": "docs/decisions/README.md",
-      "size_bytes": 2304
+      "size_bytes": 2435
     },
     {
       "digest": "sha256:9d903133d4523f42aebdaacad1d825b4e364d608102bc68af2245637db632746",
@@ -3662,9 +3682,9 @@
       "size_bytes": 2852
     },
     {
-      "digest": "sha256:e6109fb747cffc920d3fe48c9bab939bdc9ce7d0dd1130f5ce50367b4d218e28",
+      "digest": "sha256:cd27da25b87b3e8ee6e03a1febe0be4a3fd9688972fbb8edc02161518090320f",
       "path": "docs/specs/SPEC-001-repository-reconciliation.md",
-      "size_bytes": 3108
+      "size_bytes": 3157
     },
     {
       "digest": "sha256:32fb944b014b961123d9929e64a735add82d1dfb1d105093326564275a163e38",

--- a/researcher/generated/corpus-summary.md
+++ b/researcher/generated/corpus-summary.md
@@ -4,13 +4,13 @@
 This is a generated view of canonical repository artifacts, not a second source of truth.
 
 - Schema: `1.0.0`
-- Source tree: `sha256:86862cd0d756cea633504f0553603296f441daba2d08c9686a87d4ce334a597d`
+- Source tree: `sha256:00bcaa9f84dd6ffa4e3e02944b7d76f4cc7465bfac5e15f711c2b6ace9fa793f`
 - Unresolved references: `0`
 
 | Artifact | Count |
 | --- | ---: |
 | Specifications | 27 |
-| Architecture decisions | 8 |
+| Architecture decisions | 9 |
 | Orchestration briefs | 7 |
 | Published skills | 17 |
 | Mechanism registry records | 22 |

--- a/researcher/scripts/tests/test_build_inventory.py
+++ b/researcher/scripts/tests/test_build_inventory.py
@@ -487,10 +487,10 @@ class RepositoryInventoryTests(unittest.TestCase):
     def test_architecture_decisions_are_inventory_backed(self) -> None:
         inventory = InventoryBuilder(ROOT).build()
         decisions = inventory["artifacts"]["architecture_decisions"]
-        self.assertEqual(decisions["count"], 8)
+        self.assertEqual(decisions["count"], 9)
         self.assertEqual(
             {record["id"] for record in decisions["records"]},
-            {f"ADR-{number:04d}" for number in range(1, 9)},
+            {f"ADR-{number:04d}" for number in range(1, 10)},
         )
 
     def test_orchestration_briefs_are_inventory_backed_and_non_authoritative(self) -> None:
@@ -882,7 +882,7 @@ class RepositoryInventoryTests(unittest.TestCase):
     def test_active_specification_binds_every_direct_dependency_revision(self) -> None:
         temporary, root = self.fixture()
         self.addCleanup(temporary.cleanup)
-        path = root / "docs/specs/SPEC-001-repository-reconciliation.md"
+        path = root / "docs/specs/SPEC-002-public-private-boundary.md"
         original = path.read_text(encoding="utf-8")
         mutated = original.replace(
             "Dependency revisions: SPEC-000@1",


### PR DESCRIPTION
## Stack

- Base: #126 (`codex/router-manifest-resume`)
- Next isolated lifecycle proposal in the linear stack
- Do not merge before its base; human merge only

## Decision

ADR-0009 proposes the exact transition:

`SPEC-001@1 implemented -> amended -> SPEC-001@2`

Revision 1 conflates neither identity in prose, but it does not normatively bind the checked canonical-source inventory to one exact Git object-format, commit, and tree snapshot. Later journal and repository-acceptance contracts require that relation without turning snapshot evidence into merge or acceptance authority. Revision 1 is also frozen to `SPEC-000@1` and cannot advance against the replacement constitution.

The replacement must keep canonical-source-tree identity distinct from Git snapshot identity, bind exact inventory and Git bytes without self-reference, reject mixed or ambiguous repository state, and grant no repository acceptance, merge, deployment, or runtime authority.

## Authority boundary

This PR only proposes the terminal revision-1 lifecycle decision. It does not create, accept, or implement SPEC-001@2; it does not change schemas or runtime code; and it grants no repository authority. A successor draft remains illegal until this exact terminal predecessor is human-merged and reachable from the lifecycle base.

Terminal SPEC-001@1 digest after this transition:

`sha256:cd27da25b87b3e8ee6e03a1febe0be4a3fd9688972fbb8edc02161518090320f`

## Verification

- Exact-base lifecycle validation against #126 head `7c0c92d`
- Python 3.12: 305/305 tests
- Node 22.13.1 runner: 82/82 tests, zero SDK calls
- Inventory: 324 artifacts, 201 canonical sources, digest `00bcaa9f84dd`
- Governance, public/export, schema, migration, platform, strict-repo, skill-health, activation, benchmark, site, Gitleaks, and diff gates pass

No merge, auto-merge, successor revision, implementation, or paid call is included.