### PR TITLE
docs(spec-002): authorize projection-boundary amendment

### DIFF
--- a/docs/decisions/0010-amend-spec-002-for-authoritative-source-binding-and-bounded-public-projections.md
+++ b/docs/decisions/0010-amend-spec-002-for-authoritative-source-binding-and-bounded-public-projections.md
@@ -1,0 +1,50 @@
+# ADR-0010: Amend SPEC-002 for authoritative source binding and bounded public projections
+
+- Status: accepted
+- Date: 2026-08-15
+- Spec: SPEC-002
+- Lifecycle transition: SPEC-002@1 -> amended -> SPEC-002@2
+
+## Context
+
+SPEC-002 revision 1 established the public/private classification boundary, allowlisted new-identity projections, private source-bound plans and receipts, deterministic rendering, and closed public staging validation.
+
+The revision does not identify the authoritative record from which a source kind, version, classification, retention, and exact bytes must be resolved. The current implementation consequently accepts a caller-supplied `source_classification` as the effective classification. A source record that declares `kind: CredentialRef` and `classification: secret_reference` can be presented to the planner as `private_operational`; an otherwise registered route can then emit an allowlisted public projection. A caller-controlled projection identity can likewise encode an exact private source digest even when the public body contains only allowlisted fields. These are normative ambiguities, not only implementation bugs: revision 1 does not define the classification high-water relation, the route's authoritative source binding, or a bounded noninterference rule for public identity and metadata.
+
+Later evidence, context, promotion, governance, and credential contracts depend on public projections that do not expose private identities, membership facts, denial details, or equality oracles. They need one portable boundary that independent implementations can reproduce without claiming universal semantic data-loss prevention.
+
+SPEC-000 revision 1 is also entering its amendment lifecycle. SPEC-002 revision 1 is frozen to `SPEC-000@1`; it cannot advance against the replacement constitution without its own revision and exact dependency binding.
+
+## Decision
+
+SPEC-002 revision 1 enters the terminal `amended` state and names `SPEC-002@2` as its only replacement. Revision 2 must preserve the allowlisted, new-identity projection architecture while defining one authoritative source-binding and bounded-declassification contract for lower-classified and public projections.
+
+Every projection input must be privately bound to exact source bytes, registered source kind and version, effective classification, retention, and the authority-owned metadata from which those properties were resolved. A request-supplied classification or kind is a constraint only; it cannot establish, replace, or lower the authoritative value. Unknown sources, conflicting bindings, unresolved classifications, and unrepresentable joins fail closed. Effective classification is computed through one declared conservative join or high-water relation, and `secret_reference` is never declassifiable.
+
+Every registered route must bind the source kind and version, effective source classification, output kind and version, exact transform version and digest, policy epoch, declared read set, and declassified output fields. Exact source identities, digests, locators, bindings, and classification evidence remain in the private plan and receipt. Public manifests and public checks remain independently verifiable without private-source access.
+
+The projection guarantee is bounded and transform-local rather than a universal semantic data-loss-prevention claim. For a fixed route, public policy, public identity input, and declared declassified field values, changing an excluded private field must not change public bytes or public-facing metadata. Projection identities, paths, digests, lineage, statuses, and diagnostics must not encode a private identity, locator, digest, membership fact, denial detail, or other private-derived equality or existence oracle.
+
+`public_derived` denotes a disclosure classification only. It does not imply evidence acceptance, human approval, promotion, deployment, read authority, or publication authority. Rendering and checking create a candidate projection. Publication or external delivery remains a separate exact-manifest authority decision under the then-effective constitution and the owning delivery specification.
+
+Revision 2 must bind the current accepted constitution revision and provide adversarial fixtures for caller relabeling, provider high-water changes after planning, unregistered or mismatched source kinds with matching fields, reference or envelope laundering, private-derived projection identities and paths, equal-visible/different-hidden transform-local noninterference, and safe denial behavior.
+
+This decision authorizes only the lifecycle transition. It does not accept revision 2, change policy or schema bytes, repair the exporter, authorize a private export, or permit publication. The replacement must enter as a digest-linked draft and complete ordinary architecture review and acceptance before implementation.
+
+## Consequences
+
+- Existing public exports must be revalidated under revision 2 before a later owner treats them as current evidence; ambiguous projections are quarantined rather than silently grandfathered.
+- Later specifications may rely on authoritative projection identity, classification, and noninterference only after revision 2 is accepted and implemented.
+- The successor implementation must add cross-runtime fixtures for classification joins, relabeling, source mutation, type laundering, identity and path oracles, public-denial behavior, deterministic replay, and rollback.
+- SPEC-002 must be revised before it can advance against `SPEC-000@2` or satisfy later same-stage dependency floors.
+- This terminal decision changes no current exporter, policy, schema, projection, or publication authority.
+
+## Alternatives considered
+
+- Patch only the current exporter. Rejected because another conforming implementation could still choose caller-provided classification or private-derived identity under the revision-1 text.
+- Treat the request's classification as authoritative. Rejected because a requester cannot safely lower a classification owned by the source record or its registry.
+- Promise universal semantic data-loss prevention. Rejected because it is neither mechanically decidable nor supported by the registered-transform architecture; the enforceable guarantee is route-bound and transform-local.
+
+## Verification
+
+The transition PR must change only lifecycle metadata in SPEC-002, add this one-purpose accepted ADR, update its index, preserve the active dependency-binding validator through a synthetic active fixture, regenerate deterministic inventory outputs, and pass the base-aware lifecycle validator against the exact parent branch. The successor and implementation PRs must separately provide the contract, fixtures, migration, rollback, and authority-separation evidence described above.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -21,3 +21,4 @@ The dependency-ordered implementation contracts live in the [specification progr
 - [ADR-0007: Amend SPEC-003 classification and reference invariants](0007-amend-spec-003-classification-and-reference-invariants.md)
 - [ADR-0008: Amend SPEC-000 for a closed authority vocabulary](0008-amend-spec-000-for-a-closed-authority-vocabulary.md)
 - [ADR-0009: Amend SPEC-001 for exact repository snapshot identity](0009-amend-spec-001-for-exact-repository-snapshot-identity.md)
+- [ADR-0010: Amend SPEC-002 for authoritative source binding and bounded public projections](0010-amend-spec-002-for-authoritative-source-binding-and-bounded-public-projections.md)

--- a/docs/specs/SPEC-002-public-private-boundary.md
+++ b/docs/specs/SPEC-002-public-private-boundary.md
@@ -1,6 +1,6 @@
 # SPEC-002: Public and private boundary
 
-Status: implemented
+Status: amended
 Revision: 1
 Revises: none
 Wave: 0
@@ -9,6 +9,8 @@ Owners: human maintainer; export steward agent
 Depends on: SPEC-000
 Dependency revisions: SPEC-000@1
 Adoption decision: ADR-0005
+Lifecycle decision: ADR-0010
+Replacement: SPEC-002@2
 
 ## Decision
 

--- a/researcher/corpus/inventory.json
+++ b/researcher/corpus/inventory.json
@@ -241,7 +241,7 @@
       ]
     },
     "architecture_decisions": {
-      "count": 9,
+      "count": 10,
       "lifecycle": [
         "accepted",
         "deprecated",
@@ -387,6 +387,19 @@
           ],
           "status": "accepted",
           "title": "Amend SPEC-001 for exact repository snapshot identity"
+        },
+        {
+          "date": "2026-08-15",
+          "digest": "sha256:9c74bc784683a57cfd0bbd38b3487e5fca0c4b0e01072ecc0de6c3a76e8c1e40",
+          "id": "ADR-0010",
+          "lifecycle_transition": "SPEC-002@1 -> amended -> SPEC-002@2",
+          "path": "docs/decisions/0010-amend-spec-002-for-authoritative-source-binding-and-bounded-public-projections.md",
+          "spec_scope": "SPEC-002",
+          "specifications": [
+            "SPEC-002"
+          ],
+          "status": "accepted",
+          "title": "Amend SPEC-002 for authoritative source binding and bounded public projections"
         }
       ]
     },
@@ -2475,16 +2488,18 @@
             "SPEC-000"
           ],
           "dependency_revisions": "SPEC-000@1",
-          "digest": "sha256:32fb944b014b961123d9929e64a735add82d1dfb1d105093326564275a163e38",
+          "digest": "sha256:b7c716de275b706b919c55e3b51901c8a928056a263a456cafb1b44547e50828",
           "id": "SPEC-002",
+          "lifecycle_decision": "ADR-0010",
           "owners": [
             "human maintainer",
             "export steward agent"
           ],
           "path": "docs/specs/SPEC-002-public-private-boundary.md",
+          "replacement": "SPEC-002@2",
           "revises": "none",
           "revision": 1,
-          "status": "implemented",
+          "status": "amended",
           "title": "Public and private boundary",
           "wave": 0
         },
@@ -3589,12 +3604,12 @@
     ]
   },
   "repository_revision": {
-    "digest": "sha256:00bcaa9f84dd6ffa4e3e02944b7d76f4cc7465bfac5e15f711c2b6ace9fa793f",
+    "digest": "sha256:dac808856b5e653ebd9fc9594a4c3e1e215cd7cf58a719ddc7faf2c0f7cf8b61",
     "git_commit_excluded_to_avoid_self_reference": true,
     "kind": "canonical_source_tree"
   },
   "schema_version": "1.0.0",
-  "source_tree_digest": "sha256:00bcaa9f84dd6ffa4e3e02944b7d76f4cc7465bfac5e15f711c2b6ace9fa793f",
+  "source_tree_digest": "sha256:dac808856b5e653ebd9fc9594a4c3e1e215cd7cf58a719ddc7faf2c0f7cf8b61",
   "sources": [
     {
       "digest": "sha256:2aebace36e5bbdd8ad93bc9c7563a0c673787838eb0f4f62a5376132d43ce616",
@@ -3662,9 +3677,14 @@
       "size_bytes": 4576
     },
     {
-      "digest": "sha256:0a90fc31db983de9dbc1918f80ded7c25a1a7214bcd3ed035f7c35fff54477a3",
+      "digest": "sha256:9c74bc784683a57cfd0bbd38b3487e5fca0c4b0e01072ecc0de6c3a76e8c1e40",
+      "path": "docs/decisions/0010-amend-spec-002-for-authoritative-source-binding-and-bounded-public-projections.md",
+      "size_bytes": 6820
+    },
+    {
+      "digest": "sha256:7186ef5cbf663377c8ddde5f4a6746a6c9a493009f7fd57133327e1404da41d8",
       "path": "docs/decisions/README.md",
-      "size_bytes": 2435
+      "size_bytes": 2616
     },
     {
       "digest": "sha256:9d903133d4523f42aebdaacad1d825b4e364d608102bc68af2245637db632746",
@@ -3687,9 +3707,9 @@
       "size_bytes": 3157
     },
     {
-      "digest": "sha256:32fb944b014b961123d9929e64a735add82d1dfb1d105093326564275a163e38",
+      "digest": "sha256:b7c716de275b706b919c55e3b51901c8a928056a263a456cafb1b44547e50828",
       "path": "docs/specs/SPEC-002-public-private-boundary.md",
-      "size_bytes": 3600
+      "size_bytes": 3649
     },
     {
       "digest": "sha256:8850f070fcf92d644da30d606cb2f11eb63ed7e9ae2c22b73aab5a185ba01f7f",

--- a/researcher/generated/corpus-summary.md
+++ b/researcher/generated/corpus-summary.md
@@ -4,13 +4,13 @@
 This is a generated view of canonical repository artifacts, not a second source of truth.
 
 - Schema: `1.0.0`
-- Source tree: `sha256:00bcaa9f84dd6ffa4e3e02944b7d76f4cc7465bfac5e15f711c2b6ace9fa793f`
+- Source tree: `sha256:dac808856b5e653ebd9fc9594a4c3e1e215cd7cf58a719ddc7faf2c0f7cf8b61`
 - Unresolved references: `0`
 
 | Artifact | Count |
 | --- | ---: |
 | Specifications | 27 |
-| Architecture decisions | 9 |
+| Architecture decisions | 10 |
 | Orchestration briefs | 7 |
 | Published skills | 17 |
 | Mechanism registry records | 22 |

--- a/researcher/scripts/tests/test_build_inventory.py
+++ b/researcher/scripts/tests/test_build_inventory.py
@@ -487,10 +487,10 @@ class RepositoryInventoryTests(unittest.TestCase):
     def test_architecture_decisions_are_inventory_backed(self) -> None:
         inventory = InventoryBuilder(ROOT).build()
         decisions = inventory["artifacts"]["architecture_decisions"]
-        self.assertEqual(decisions["count"], 9)
+        self.assertEqual(decisions["count"], 10)
         self.assertEqual(
             {record["id"] for record in decisions["records"]},
-            {f"ADR-{number:04d}" for number in range(1, 10)},
+            {f"ADR-{number:04d}" for number in range(1, 11)},
         )
 
     def test_orchestration_briefs_are_inventory_backed_and_non_authoritative(self) -> None:
@@ -884,14 +884,25 @@ class RepositoryInventoryTests(unittest.TestCase):
         self.addCleanup(temporary.cleanup)
         path = root / "docs/specs/SPEC-002-public-private-boundary.md"
         original = path.read_text(encoding="utf-8")
-        mutated = original.replace(
-            "Dependency revisions: SPEC-000@1",
-            "Dependency revisions: none",
-            1,
+        mutated = (
+            original.replace("Status: amended\n", "Status: implemented\n", 1)
+            .replace(
+                "Lifecycle decision: ADR-0010\nReplacement: SPEC-002@2\n",
+                "",
+                1,
+            )
+            .replace(
+                "Dependency revisions: SPEC-000@1\n",
+                "Dependency revisions: none\n",
+                1,
+            )
         )
         self.assertNotEqual(original, mutated)
         path.write_text(mutated, encoding="utf-8")
-        self.assertIn("SPEC_DEPENDENCY_REVISION_MISMATCH", finding_codes(root))
+        self.assertEqual(
+            finding_codes(root),
+            {"SPEC_DEPENDENCY_REVISION_MISMATCH"},
+        )
 
     def test_downstream_active_spec_requires_authority_vocabulary_floor(self) -> None:
         temporary, root = self.fixture()


### PR DESCRIPTION
## Stack

This draft is stacked directly on #127 (`codex/spec-001-amendment-decision`) at exact parent `ec6f25c609029474b7bfcbebba20d7792f3d01dd`. It must not merge before its parent stack, and merge authority remains human-only.

## What changed

- adds accepted one-purpose ADR-0010 for `SPEC-002@1 -> amended -> SPEC-002@2`
- changes only SPEC-002 revision-1 lifecycle metadata: `implemented -> amended`, lifecycle decision, and replacement
- records the revision-1 normative gap: caller-supplied source classification and projection identity can launder higher-classified source state or create a private equality oracle
- requires revision 2 to define authoritative source binding, conservative classification high-water, route and transform binding, bounded transform-local noninterference, and separation of disclosure class from publication authority
- updates the ADR index, isolated dependency fixture, and deterministic generated inventory views

## Exact identities

- parent SPEC-002@1: `sha256:32fb944b014b961123d9929e64a735add82d1dfb1d105093326564275a163e38`
- terminal SPEC-002@1: `sha256:b7c716de275b706b919c55e3b51901c8a928056a263a456cafb1b44547e50828`
- ADR-0010: `sha256:9c74bc784683a57cfd0bbd38b3487e5fca0c4b0e01072ecc0de6c3a76e8c1e40`
- inventory: 325 artifacts, 202 sources, digest `dac808856b5e653ebd9fc9594a4c3e1e215cd7cf58a719ddc7faf2c0f7cf8b61`

## Verification

- base-aware specification lifecycle: pass against exact #127 head
- Python 3.12: 305/305 tests
- TypeScript schema contract: 20/20 tests
- exact Node 22.13.1 SDK runner: 82/82 tests
- Router and effectiveness dry plans under SDK-denial instrumentation: pass, zero calls
- inventory, public boundary, governance, export, schema, migration, platform, strict repository, skill health, activation, deterministic benchmark, generated-site, diff, and Gitleaks gates: pass
- independent adversarial review: pass, no blocker or high finding

## Authority boundary

This PR authorizes only the terminal lifecycle transition if a human merges it through the full parent stack. It does not accept SPEC-002@2, change exporter or policy behavior, authorize a private export, permit publication, implement a successor contract, or grant merge, deployment, or runtime authority.

## Inherited residual

The zero-call benchmark dependency graph still reports one high and two moderate package records through `@cursor/sdk -> @connectrpc/connect-node -> undici`, with no available fix. This PR does not change that graph; live SDK activation remains blocked pending a separate human containment decision.